### PR TITLE
🐛 history 快捷键改为 meta [ 和 meta ]

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -115,10 +115,10 @@ fn main() -> wry::Result<()> {
         if (event.key == "ArrowDown" && event.metaKey){
           window.scrollTo(0, document.body.scrollHeight);
         }
-        if (event.key == "ArrowLeft" && event.metaKey){
+        if (event.key == "[" && event.metaKey){
           window.history.go(-1);
         }
-        if (event.key == "ArrowRight" && event.metaKey){
+        if (event.key == "]" && event.metaKey){
           window.history.go(1);
         }
         if (event.key == "r" && event.metaKey){


### PR DESCRIPTION
meta + ArrowLeft/ArrowRight 一般被用做跳转到编辑区域的最前和最后，Safari 导航默认为 meta + [ ]