### PR TITLE
:bug: 修复打包后无法读取配置文件导致崩溃的问题

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -108,8 +108,8 @@ fn main() -> wry::Result<()> {
 }
 
 fn get_windows_config() -> WindowConfig {
-    let config_file = File::open("./tauri.conf.json").unwrap();
-    let config: Config = serde_json::from_reader(config_file).unwrap();
+    let config_file = include_str!("../tauri.conf.json");
+    let config: Config = serde_json::from_str(config_file).expect("failed to parse windows config");
 
     config.tauri.windows[0].clone()
 }


### PR DESCRIPTION
Fixed
![telegram-cloud-photo-size-5-6253693831946023097-y](https://user-images.githubusercontent.com/38807139/197952949-a597acce-8442-4914-b307-61287abc4dcd.jpg)
