### PR TITLE
:zap: 优化获取 `WindowConfig` 部分的代码逻辑

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,4 +1,3 @@
-use std::fs::File;
 use tauri_utils::config::{Config, WindowConfig};
 
 fn main() -> wry::Result<()> {
@@ -45,7 +44,7 @@ fn main() -> wry::Result<()> {
         transparent,
         fullscreen,
         ..
-    } = get_windows_config();
+    } = get_windows_config().unwrap_or(WindowConfig::default());
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new()
         .with_resizable(resizable)
@@ -107,9 +106,9 @@ fn main() -> wry::Result<()> {
     });
 }
 
-fn get_windows_config() -> WindowConfig {
+fn get_windows_config() -> Option<WindowConfig> {
     let config_file = include_str!("../tauri.conf.json");
     let config: Config = serde_json::from_str(config_file).expect("failed to parse windows config");
 
-    config.tauri.windows[0].clone()
+    config.tauri.windows.iter().next().cloned()
 }


### PR DESCRIPTION
1.  避免使用 `clone`
2. 在获取配置失败时给予默认值