### PR TITLE
refactor: 💡 分割 menus/window/webview 三个模块到单独文件, 添加多平台支持

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "start": "npm run dev",
     "dev": "npm run tauri dev",
-    "build": "npm run tauri build -- --target universal-apple-darwin",
+    "build": "npm run tauri build",
     "tauri": "tauri"
   },
   "license": "MIT",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,87 +1,55 @@
 use tauri_utils::config::{Config, WindowConfig};
+use wry::application::{
+    event::{Event, StartCause, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    menu::MenuType,
+    window::Fullscreen,
+};
+
+mod menus_builder;
+mod webview_builder;
+mod window_builder;
 
 fn main() -> wry::Result<()> {
-    use wry::{
-        application::{
-            accelerator::{Accelerator, SysMods},
-            event::{Event, StartCause, WindowEvent},
-            event_loop::{ControlFlow, EventLoop},
-            keyboard::KeyCode,
-            menu::{MenuBar as Menu, MenuItem, MenuItemAttributes, MenuType},
-            platform::macos::WindowBuilderExtMacOS,
-            window::{Fullscreen, Window, WindowBuilder},
-        },
-        webview::WebViewBuilder,
-    };
+    // --------------------------------------------------------
+    // 获取 tauri.conf.json 配置
+    // --------------------------------------------------------
+    let window_config = get_windows_config().unwrap_or(WindowConfig::default());
 
-    let mut menu_bar_menu = Menu::new();
-    let mut first_menu = Menu::new();
-
-    first_menu.add_native_item(MenuItem::Hide);
-    first_menu.add_native_item(MenuItem::EnterFullScreen);
-    first_menu.add_native_item(MenuItem::Minimize);
-    first_menu.add_native_item(MenuItem::Separator);
-    first_menu.add_native_item(MenuItem::Copy);
-    first_menu.add_native_item(MenuItem::Cut);
-    first_menu.add_native_item(MenuItem::Paste);
-    first_menu.add_native_item(MenuItem::Undo);
-    first_menu.add_native_item(MenuItem::Redo);
-    first_menu.add_native_item(MenuItem::SelectAll);
-    first_menu.add_native_item(MenuItem::Separator);
-    let close_item = first_menu.add_item(
-        MenuItemAttributes::new("CloseWindow")
-            .with_accelerators(&Accelerator::new(SysMods::Cmd, KeyCode::KeyW)),
-    );
-    first_menu.add_native_item(MenuItem::Quit);
-
-    menu_bar_menu.add_submenu("App", true, first_menu);
-
-    let WindowConfig {
-        url,
-        width,
-        height,
-        resizable,
-        transparent,
-        fullscreen,
-        ..
-    } = get_windows_config().unwrap_or(WindowConfig::default());
+    // --------------------------------------------------------
+    // 创建 window
+    // --------------------------------------------------------
     let event_loop = EventLoop::new();
-    let window = WindowBuilder::new()
-        .with_resizable(resizable)
-        .with_titlebar_transparent(transparent)
-        .with_fullscreen(if fullscreen {
+
+    let (menu_bar_menu, custome_menu_map) =
+        menus_builder::get_menus_with_platform_spec(&window_config);
+
+    // 平台单独的配置在这个方法里, 公用的在下面
+    let window_builder =
+        window_builder::get_windows_builder_with_platform_spec_setting(&window_config);
+
+    // 通用的配置在这里, 平台单独的配置在方法里
+    let window = window_builder
+        .with_resizable(window_config.resizable)
+        .with_fullscreen(if window_config.fullscreen {
             Some(Fullscreen::Borderless(None))
         } else {
             None
         })
-        .with_fullsize_content_view(true)
-        .with_titlebar_buttons_hidden(false)
-        .with_title_hidden(true)
         .with_menu(menu_bar_menu)
-        .with_inner_size(wry::application::dpi::LogicalSize::new(width, height))
+        .with_inner_size(wry::application::dpi::LogicalSize::new(
+            window_config.width,
+            window_config.height,
+        ))
         .build(&event_loop)
         .unwrap();
 
-    let handler = move |window: &Window, req: String| {
-        if req == "drag_window" {
-            let _ = window.drag_window();
-        } else if req == "fullscreen" {
-            if window.fullscreen().is_some() {
-                window.set_fullscreen(None);
-            } else {
-                window.set_fullscreen(Some(Fullscreen::Borderless(None)));
-            }
-        }
-    };
+    // --------------------------------------------------------
+    // 处理 webview
+    // --------------------------------------------------------
+    let webview = webview_builder::get_webview(&window_config, window);
 
-    let _webview = WebViewBuilder::new(window)?
-        .with_url(&url.to_string())?
-        // .with_devtools(true)
-        .with_initialization_script(include_str!("pake.js"))
-        .with_ipc_handler(handler)
-        .build()?;
-
-    // _webview.open_devtools();
+    // webview.open_devtools();
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 
@@ -96,8 +64,11 @@ fn main() -> wry::Result<()> {
                 origin: MenuType::MenuBar,
                 ..
             } => {
-                if menu_id == close_item.clone().id() {
-                    _webview.window().set_minimized(true);
+                // --------------------------------------------------------
+                // 处理 自定义菜单
+                // --------------------------------------------------------
+                if custome_menu_map.is(menus_builder::CustomeMenuKind::CLOSE, &menu_id) {
+                    webview.window().set_minimized(true);
                 }
                 println!("Clicked on {:?}", menu_id);
             }
@@ -106,6 +77,11 @@ fn main() -> wry::Result<()> {
     });
 }
 
+/**
+ * --------------------------------------------------------
+ * 获取 tauri.config.json 配置
+ * --------------------------------------------------------
+ */
 fn get_windows_config() -> Option<WindowConfig> {
     let config_file = include_str!("../tauri.conf.json");
     let config: Config = serde_json::from_str(config_file).expect("failed to parse windows config");

--- a/src-tauri/src/menus_builder.rs
+++ b/src-tauri/src/menus_builder.rs
@@ -1,0 +1,168 @@
+use std::collections::HashMap;
+use tauri_utils::config::WindowConfig;
+use wry::application::{
+    accelerator::{Accelerator, SysMods},
+    keyboard::KeyCode,
+    menu::{MenuBar as Menu, MenuId, MenuItem, MenuItemAttributes},
+};
+
+/**
+ * --------------------------------------------------------
+ * 配置各个系统的菜单, 因为各个系统的快捷键/菜单习惯不一样
+ * --------------------------------------------------------
+ */
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum CustomeMenuKind {
+    CLOSE,
+}
+
+pub struct CustomeMenuMap {
+    map: HashMap<CustomeMenuKind, MenuId>,
+}
+
+impl CustomeMenuMap {
+    pub fn is(&self, kind: CustomeMenuKind, menu_id: &MenuId) -> bool {
+        let kind_menu = self.map.get(&kind);
+
+        let is_eq = kind_menu.unwrap() == menu_id;
+
+        is_eq
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn get_menus_with_platform_spec(window_config: &WindowConfig) -> (Menu, CustomeMenuMap) {
+    let mut menu_bar_menu = Menu::new();
+    let mut first_menu = Menu::new();
+
+    // --------------------------------------------------------
+    // macOS 通用系统菜单
+    // --------------------------------------------------------
+    first_menu.add_native_item(MenuItem::Hide);
+    first_menu.add_native_item(MenuItem::EnterFullScreen);
+    first_menu.add_native_item(MenuItem::Minimize);
+    first_menu.add_native_item(MenuItem::Separator);
+    first_menu.add_native_item(MenuItem::Copy);
+    first_menu.add_native_item(MenuItem::Cut);
+    first_menu.add_native_item(MenuItem::Paste);
+    first_menu.add_native_item(MenuItem::Undo);
+    first_menu.add_native_item(MenuItem::Redo);
+    first_menu.add_native_item(MenuItem::SelectAll);
+    first_menu.add_native_item(MenuItem::Separator);
+
+    // --------------------------------------------------------
+    // 添加自定义菜单 ⌘ + W , 事件处理在 eventloop 中, 将窗口 minimum
+    // --------------------------------------------------------
+    let close_item = first_menu.add_item(
+        MenuItemAttributes::new("CloseWindow")
+            .with_accelerators(&Accelerator::new(SysMods::Cmd, KeyCode::KeyW)),
+    );
+
+    // --------------------------------------------------------
+    // Quit 添加到最后
+    // --------------------------------------------------------
+    first_menu.add_native_item(MenuItem::Quit);
+
+    // --------------------------------------------------------
+    // 组装菜单栏
+    // --------------------------------------------------------
+    menu_bar_menu.add_submenu(&window_config.title, true, first_menu);
+
+    // --------------------------------------------------------
+    // 组装自定义菜单的 map, 给外面用
+    // --------------------------------------------------------
+    let mut map = HashMap::new();
+
+    map.insert(CustomeMenuKind::CLOSE, close_item.clone().id());
+
+    let custome_menu_map = CustomeMenuMap { map };
+
+    (menu_bar_menu, custome_menu_map)
+}
+
+#[cfg(target_os = "windows")]
+pub fn get_menus_with_platform_spec(window_config: &WindowConfig) -> (Menu, CustomeMenuMap) {
+    let mut menu_bar_menu = Menu::new();
+    let mut first_menu = Menu::new();
+
+    // --------------------------------------------------------
+    // Windows 通用系统菜单
+    // --------------------------------------------------------
+    first_menu.add_native_item(MenuItem::Hide);
+    first_menu.add_native_item(MenuItem::EnterFullScreen);
+    first_menu.add_native_item(MenuItem::Minimize);
+    first_menu.add_native_item(MenuItem::Separator);
+
+    // --------------------------------------------------------
+    // 添加自定义菜单 Ctrl + W , 事件处理在 eventloop 中, 将窗口 minimum
+    // --------------------------------------------------------
+    let close_item = first_menu.add_item(
+        MenuItemAttributes::new("CloseWindow")
+            .with_accelerators(&Accelerator::new(SysMods::Cmd, KeyCode::KeyW)),
+    );
+
+    // --------------------------------------------------------
+    // Quit 添加到最后
+    // --------------------------------------------------------
+    first_menu.add_native_item(MenuItem::Quit);
+
+    // --------------------------------------------------------
+    // 组装菜单栏
+    // --------------------------------------------------------
+    menu_bar_menu.add_submenu(&window_config.title, true, first_menu);
+
+    // --------------------------------------------------------
+    // 组装自定义菜单的 map, 给外面用
+    // --------------------------------------------------------
+    let mut map = HashMap::new();
+
+    map.insert(CustomeMenuKind::CLOSE, close_item.clone().id());
+
+    let custome_menu_map = CustomeMenuMap { map };
+
+    (menu_bar_menu, custome_menu_map)
+}
+
+#[cfg(target_os = "linux")]
+pub fn get_menus_with_platform_spec(window_config: &WindowConfig) -> (Menu, CustomeMenuMap) {
+    let mut menu_bar_menu = Menu::new();
+    let mut first_menu = Menu::new();
+
+    // --------------------------------------------------------
+    // Windows 通用系统菜单
+    // --------------------------------------------------------
+    first_menu.add_native_item(MenuItem::Hide);
+    first_menu.add_native_item(MenuItem::EnterFullScreen);
+    first_menu.add_native_item(MenuItem::Minimize);
+    first_menu.add_native_item(MenuItem::Separator);
+
+    // --------------------------------------------------------
+    // 添加自定义菜单 Ctrl + W , 事件处理在 eventloop 中, 将窗口 minimum
+    // --------------------------------------------------------
+    let close_item = first_menu.add_item(
+        MenuItemAttributes::new("CloseWindow")
+            .with_accelerators(&Accelerator::new(SysMods::Cmd, KeyCode::KeyW)),
+    );
+
+    // --------------------------------------------------------
+    // Quit 添加到最后
+    // --------------------------------------------------------
+    first_menu.add_native_item(MenuItem::Quit);
+
+    // --------------------------------------------------------
+    // 组装菜单栏
+    // --------------------------------------------------------
+    menu_bar_menu.add_submenu(&window_config.title, true, first_menu);
+
+    // --------------------------------------------------------
+    // 组装自定义菜单的 map, 给外面用
+    // --------------------------------------------------------
+    let mut map = HashMap::new();
+
+    map.insert(CustomeMenuKind::CLOSE, close_item.clone().id());
+
+    let custome_menu_map = CustomeMenuMap { map };
+
+    (menu_bar_menu, custome_menu_map)
+}

--- a/src-tauri/src/webview_builder.rs
+++ b/src-tauri/src/webview_builder.rs
@@ -1,0 +1,34 @@
+use tauri_utils::config::WindowConfig;
+use wry::{
+    application::window::{Fullscreen, Window},
+    webview::{WebView, WebViewBuilder},
+};
+
+pub fn get_webview(window_config: &WindowConfig, window: Window) -> WebView {
+    // --------------------------------------------------------
+    // 创建 webview
+    // --------------------------------------------------------
+    let handler = move |window: &Window, req: String| {
+        if req == "drag_window" {
+            let _ = window.drag_window();
+        } else if req == "fullscreen" {
+            if window.fullscreen().is_some() {
+                window.set_fullscreen(None);
+            } else {
+                window.set_fullscreen(Some(Fullscreen::Borderless(None)));
+            }
+        }
+    };
+
+    let webview = WebViewBuilder::new(window)
+        .unwrap()
+        .with_url(&window_config.url.to_string())
+        .unwrap()
+        // .with_devtools(true)
+        .with_initialization_script(include_str!("pake.js"))
+        .with_ipc_handler(handler)
+        .build()
+        .unwrap();
+
+    webview
+}

--- a/src-tauri/src/window_builder.rs
+++ b/src-tauri/src/window_builder.rs
@@ -1,0 +1,38 @@
+use tauri_utils::config::WindowConfig;
+use wry::application::window::WindowBuilder;
+
+/**
+ * --------------------------------------------------------
+ * 获取 wry window_builder, 但各个平台的独立配置可以在这里写
+ * --------------------------------------------------------
+ */
+#[cfg(target_os = "macos")]
+pub fn get_windows_builder_with_platform_spec_setting(
+    window_config: &WindowConfig,
+) -> WindowBuilder {
+    use wry::application::platform::macos::WindowBuilderExtMacOS;
+
+    let window = WindowBuilder::new()
+        .with_titlebar_transparent(window_config.transparent)
+        .with_fullsize_content_view(true)
+        .with_titlebar_buttons_hidden(false)
+        .with_title_hidden(true);
+
+    window
+}
+
+#[cfg(target_os = "windows")]
+pub fn get_windows_builder(window_config: &WindowConfig) -> WindowBuilder {
+    use wry::application::platform::windows::WindowBuilderExtWindows;
+
+    let window = WindowBuilder::new().with_title("");
+
+    window
+}
+
+#[cfg(target_os = "linux")]
+pub fn get_windows_builder(window_config: &WindowConfig) -> WindowBuilder {
+    let window = WindowBuilder::new();
+
+    window
+}


### PR DESCRIPTION
当前只在 macOS 验证打包, 等待 window 打包验证, linux WSL 不知道行不行得通.