### PR TITLE
:rotating_light: use `// @ts-check` in a JavaScript file

### DIFF
--- a/src-tauri/src/pake.js
+++ b/src-tauri/src/pake.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * @typedef {string} KeyboardKey `event.key` 的代号，
  * 见 <https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values>
@@ -117,11 +119,11 @@ window.addEventListener('DOMContentLoaded', (_event) => {
     }
   });
 
-  domEl.addEventListener('touchstart', (e) => {
+  domEl.addEventListener('touchstart', () => {
     window.ipc.postMessage('drag_window');
   });
 
-  domEl.addEventListener('dblclick', (e) => {
+  domEl.addEventListener('dblclick', () => {
     window.ipc.postMessage('fullscreen');
   });
 
@@ -154,6 +156,9 @@ function setDefaultZoom() {
   }
 }
 
+/**
+ * @param {(htmlZoom: string) => string} [zoomRule]
+ */
 function zoomCommon(zoomRule) {
   const htmlZoom = window.localStorage.getItem('htmlZoom') || '100%';
   const html = document.getElementsByTagName('html')[0];


### PR DESCRIPTION
## 动机

Pake.js 中的代码越来越多，每个人的代码风格也不相同，暂时使用 `// @ts-check` 来做统一和约束以及检查类型的工作。

后续是否继续拆分以及使用 TypeScript 可以再讨论。


## 参考
[Type Checking JavaScript Files](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html)