### PR TITLE
Build Script, based on Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ output
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
+
+__pycache__/

--- a/app.toml
+++ b/app.toml
@@ -1,0 +1,74 @@
+[[app]]
+id = "twitter"
+url = "https://twitter.com/"
+# see https://specifications.freedesktop.org/menu-spec/latest/apa.html
+category = "Network"
+
+[app.display_name]
+default = "Twitter"
+zh_CN = "推特"
+zh_TW = "Twitter"
+
+[[app]]
+id = "translate"
+url = "https://translate.google.com/"
+category = "Utility"
+
+[app.display_name]
+default = "Google Translate"
+zh_CN = "谷歌翻译"
+zh_TW = "Google 翻譯"
+
+[[app]]
+id = "youtube"
+url = "https://youtube.com"
+category = "Video"
+
+[app.display_name]
+default = "YouTube"
+zh = "YouTube"
+
+[[app]]
+id = "reference"
+url = "https://wangchujiang.com/reference/index.html"
+category = "Development"
+
+[app.display_name]
+default = "Reference"
+zh = "Reference"
+
+[[app]]
+id = "code"
+url = "https://riju.codes/"
+category = "Development"
+
+[app.display_name]
+default = "Code"
+zh = "Code"
+
+[[app]]
+id = "yuque"
+url = "https://www.yuque.com/"
+category = "Office"
+
+[app.display_name]
+default = "YuQue"
+zh = "语雀"
+
+[[app]]
+id = "flomo"
+url = "https://flomoapp.com/mine"
+category = "Office"
+
+[app.display_name]
+default = "Flomo"
+zh = "浮墨"
+
+[[app]]
+id = "weread"
+url = "https://weread.qq.com/"
+category = "Network"
+
+[app.display_name]
+default = "WeRead"
+zh = "微信阅读"

--- a/script/README.md
+++ b/script/README.md
@@ -1,0 +1,25 @@
+# Pake Builder
+
+## 使用说明
+
+- Python 版本要求 3.11 以上
+- 运行 `build.py` 自动编译当前架构的程序。
+
+## TODO
+
+### High-levels
+
+- [ ] 共享编译缓存 (target)
+- [ ] 可以用 CI 建構（上傳 master 時自動編譯上傳）
+- [ ] 支援跨平台編譯 (#96)
+
+### Low-levels
+
+- [x] 避免写死逻辑
+- [ ] 移植 Tauri 的文件生成逻辑
+- [ ] 写个 `BuilderExecutor`
+- [ ] 自动拷贝当前 Git 树到 tmp 文件夹
+- [ ] 写个 `AppBuildExecutor` 进行 app 面的建置与 tmp 管理
+- [ ] 与 Linux/Windows 作者 (@Tlntin) 合作移植 Windows / Linux 的编译逻辑
+- [ ] 乱序优化编译逻辑
+- [ ] 降低 Python 的需求版本 (到 3.9 ↓)

--- a/script/build.py
+++ b/script/build.py
@@ -1,0 +1,8 @@
+from pake_builder import MetaReader, get_desktop_file_content
+
+mr = MetaReader("../app.toml")
+data = mr.read()
+
+data = data["app"][0]
+
+print(get_desktop_file_content(data))

--- a/script/pake_builder/__init__.py
+++ b/script/pake_builder/__init__.py
@@ -1,0 +1,7 @@
+from .meta import AppMeta, AppTomlStructure, MetaReader
+from .desktop import get_desktop_file_content
+
+__all__ = [
+    "AppMeta", "AppTomlStructure", "MetaReader",
+    "get_desktop_file_content"
+]

--- a/script/pake_builder/builders/abstract.py
+++ b/script/pake_builder/builders/abstract.py
@@ -17,15 +17,15 @@ class FileBuilderAbstract(ABC):
 
     Builder 会从 Executor 收到三样参数：
 
-    - ``root``: 项目的根目录，可以理解成 ``README.md`` 和
-      ``package.json`` 所在的目录。届时收到的 root 会放置在
+    -   ``root``: 项目的根目录，可以理解成 ``README.md`` 和
+        ``package.json`` 所在的目录。届时收到的 root 会放置在
         /tmp 缓存文件夹内（每个 app 一个 root）——所以请尽情修改里面的内容。
-    - ``meta``: 这个 app 项目的元数据，是一个 ``AppMeta`` 对象。
-      里面包含软件的代号、分类，以及各地区语言的对应软件名称。
-      详情参阅 ``AppMeta``。
-    - ``platform``: 编译平台的信息，包含目的平台的代称，以及是否是跨平台编译。
-      这个 ``platform`` 可以帮助您“条件生成”文件，比如在 Linux 平台下生成
-      ``.desktop`` 而其他平台不进行生成。
+    -   ``meta``: 这个 app 项目的元数据，是一个 ``AppMeta`` 对象。
+        里面包含软件的代号、分类，以及各地区语言的对应软件名称。
+        详情参阅 ``AppMeta``。
+    -   ``platform``: 编译平台的信息，包含目的平台的代称，以及是否是跨平台编译。
+        这个 ``platform`` 可以帮助您“条件生成”文件，比如在 Linux 平台下生成
+        ``.desktop`` 而其他平台不进行生成。
 
     ``target_path`` 和 ``build`` 作为抽象方法 (abstract method)，
     是必须复写 (override) 的方法。``write`` 除非要进行条件生成，

--- a/script/pake_builder/builders/abstract.py
+++ b/script/pake_builder/builders/abstract.py
@@ -1,0 +1,57 @@
+"""Pake Builder – 文件生成模块的抽象
+
+将各个文件的生成逻辑抽象为一个类，方便之后写个 executor
+全自动运行。虽然高度抽象，但仍然保有极大自定义生成逻辑的空间
+（比如根据平台决定要不要生成文件，见 ``desktop.py``）。
+
+详情见 ``FileBuilderAbstract``。
+"""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from ..platform import Platform
+from ..meta import AppMeta
+
+class FileBuilderAbstract(ABC):
+    """文件生成器的抽象类
+
+    Builder 会从 Executor 收到三样参数：
+
+    - ``root``: 项目的根目录，可以理解成 ``README.md`` 和
+      ``package.json`` 所在的目录。届时收到的 root 会放置在
+        /tmp 缓存文件夹内（每个 app 一个 root）——所以请尽情修改里面的内容。
+    - ``meta``: 这个 app 项目的元数据，是一个 ``AppMeta`` 对象。
+      里面包含软件的代号、分类，以及各地区语言的对应软件名称。
+      详情参阅 ``AppMeta``。
+    - ``platform``: 编译平台的信息，包含目的平台的代称，以及是否是跨平台编译。
+      这个 ``platform`` 可以帮助您“条件生成”文件，比如在 Linux 平台下生成
+      ``.desktop`` 而其他平台不进行生成。
+
+    ``target_path`` 和 ``build`` 作为抽象方法 (abstract method)，
+    是必须复写 (override) 的方法。``write`` 除非要进行条件生成，
+    否则维持原状即可。如果要进行条件生成，绝大多数的情况也可以直接呼叫
+    ``super().write()`` 进入原始的写入函数（示例参考 ``desktop.py``）。
+    """
+
+    def __init__(self, root: Path, meta: AppMeta, platform: Platform) -> None:
+        super().__init__()
+        self.root = root
+        self.meta = meta
+        self.platform = platform
+
+    @abstractmethod
+    def target_path(self, root: Path) -> Path: pass
+
+    @abstractmethod
+    def build(self) -> bytes: pass
+
+    def write(self) -> None:
+        filename = self.target_path(self.root)
+
+        try:
+            with open(filename, "wb") as f:
+                f.write(self.build())
+        except FileNotFoundError as e:
+            print(f"{e.filename} does not exist. Creating it...")
+            (filename / '..').mkdir(parents=True, exist_ok=False)
+            return self.write()

--- a/script/pake_builder/builders/desktop.py
+++ b/script/pake_builder/builders/desktop.py
@@ -1,0 +1,44 @@
+"""Pake Builder – ``.desktop`` 文件生成模块
+
+For linux.
+"""
+
+from pathlib import Path
+from .abstract import FileBuilderAbstract
+
+
+class DesktopFileBuilder(FileBuilderAbstract):
+    def _id(self) -> str:
+        return f"run-pake-{self.meta['id']}"
+
+    def target_path(self, root: Path) -> Path:
+        return root / "src-tauri" / "assets" / f"{self._id()}.desktop"
+
+    def build(self) -> bytes:
+        id = self._id()
+        meta = self.meta
+
+        buf = [
+            "[Desktop Entry]",
+            "Type=Application",
+            "Encoding=UTF-8",
+            "StartupNotify=true",
+            "Terminal=false",
+            f"Categories={meta['category']}" if "category" in meta else None,
+            f"Exec={id}",
+            f"Icon={id}",
+        ]
+
+        for lang, value in meta["display_name"].items():
+            key = f"Name[{lang}]" if lang != "default" else "Name"
+
+            buf.append(f"{key}={value}")
+
+        return "\n".join(filter(None, buf)).encode("UTF-8")
+
+    def write(self) -> None:
+        if self.platform.target == "linux":
+            super().write()
+        else:
+            # Not on Linux, ignore.
+            pass

--- a/script/pake_builder/builders/tauri.py
+++ b/script/pake_builder/builders/tauri.py
@@ -1,0 +1,12 @@
+"""Pake Builder – Tauri 文件生成模块"""
+
+from pathlib import Path
+from .abstract import FileBuilderAbstract
+
+class TauriConfigFileBuilder(FileBuilderAbstract):
+    def target_path(self, root: Path) -> Path:
+        return root / "src-tauri" / "tauri.conf.json"
+
+    def build(self) -> bytes:
+        # TODO
+        return super().build()

--- a/script/pake_builder/meta.py
+++ b/script/pake_builder/meta.py
@@ -1,0 +1,49 @@
+"""Pake Builder – 官方打包软件配置读取模块
+
+这个模块可以读取 ``app.toml`` 并
+返回一个方便用来处理的结构。
+"""
+
+import tomllib
+from typing import NotRequired, TypedDict, cast
+
+
+class AppMeta(TypedDict):
+    '''App 元数据
+
+    - id: App 的无空格、纯小写 ID。适合用于包名。
+    - url: App 对应的网站链结。
+    - category: App 的分类。列表
+      [可参见此处](https://specifications.freedesktop.org/menu-spec/latest/apas02.html)。
+    - display_name: App 的显示名称。“default”为默认名称；
+      其他为各地区语言代号及其对应名称。'''
+    id: str
+    url: str
+    category: NotRequired[str]
+    display_name: dict[str, str]
+
+
+class AppTomlStructure(TypedDict):
+    '''``app.toml`` 的结构'''
+    app: list[AppMeta]
+
+
+class MetaReader:
+    '''``app.toml`` 的带缓存读取器'''
+    cache: AppTomlStructure | None = None
+
+    def __init__(self, filename: str):
+        self.filename = filename
+
+    def _read(self) -> AppTomlStructure:
+        with open(self.filename, "rb") as m:
+            data = tomllib.load(m)
+
+            # FIXME: type checking
+            return cast(AppTomlStructure, data)
+
+    def read(self) -> AppTomlStructure:
+        if not self.cache:
+            self.cache = self._read()
+
+        return self.cache

--- a/script/pake_builder/meta.py
+++ b/script/pake_builder/meta.py
@@ -11,12 +11,12 @@ from typing import NotRequired, TypedDict, cast
 class AppMeta(TypedDict):
     '''App 元数据
 
-    - id: App 的无空格、纯小写 ID。适合用于包名。
-    - url: App 对应的网站链结。
-    - category: App 的分类。列表
-      [可参见此处](https://specifications.freedesktop.org/menu-spec/latest/apas02.html)。
-    - display_name: App 的显示名称。“default”为默认名称；
-      其他为各地区语言代号及其对应名称。'''
+    -   id: App 的无空格、纯小写 ID。适合用于包名。
+    -   url: App 对应的网站链结。
+    -   category: App 的分类。列表
+        [可参见此处](https://specifications.freedesktop.org/menu-spec/latest/apas02.html)。
+    -   display_name: App 的显示名称。“default”为默认名称；
+        其他为各地区语言代号及其对应名称。'''
     id: str
     url: str
     category: NotRequired[str]

--- a/script/pake_builder/platform.py
+++ b/script/pake_builder/platform.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from typing import Literal
+
+TargetPlatform = Literal["linux", "windows", "macos"]
+
+@dataclass
+class Platform:
+    '''平台信息
+
+    - target: 目标平台，可能的值有 ``linux``、``windows``、``macos``。
+    - cross_compile: 是不是跨平台编译？如果是，那 ``cross_compile`` 的值
+      会是 ``target`` 可能值的其中一个；如果不是，则为 ``None``。'''
+    target: TargetPlatform
+    cross_compile: TargetPlatform | None

--- a/script/pake_builder/platform.py
+++ b/script/pake_builder/platform.py
@@ -7,8 +7,8 @@ TargetPlatform = Literal["linux", "windows", "macos"]
 class Platform:
     '''平台信息
 
-    - target: 目标平台，可能的值有 ``linux``、``windows``、``macos``。
-    - cross_compile: 是不是跨平台编译？如果是，那 ``cross_compile`` 的值
-      会是 ``target`` 可能值的其中一个；如果不是，则为 ``None``。'''
+    -   target: 目标平台，可能的值有 ``linux``、``windows``、``macos``。
+    -   cross_compile: 是不是跨平台编译？如果是，那 ``cross_compile`` 的值
+        会是 ``target`` 可能值的其中一个；如果不是，则为 ``None``。'''
     target: TargetPlatform
     cross_compile: TargetPlatform | None


### PR DESCRIPTION
Related: #98 

## TODO

### High-levels

- [ ] 共享编译缓存 (target)
- [ ] 可以用 CI 建構（上傳 master 時自動編譯上傳）
- [ ] 支援跨平台編譯 (#96)

### Low-levels

- [x] 避免写死逻辑
- [ ] 移植 Tauri 的文件生成逻辑
- [ ] 写个 `BuilderExecutor`
- [ ] 自动拷贝当前 Git 树到 tmp 文件夹
- [ ] 写个 `AppBuildExecutor` 进行 app 面的建置与 tmp 管理
- [ ] 与 Linux/Windows 作者 (@Tlntin) 合作移植 Windows / Linux 的编译逻辑
- [ ] 乱序优化编译逻辑
- [ ] 降低 Python 的需求版本 (到 3.9 ↓)
