### PR TITLE
✨ Use engines to enforce npm/node versions

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -6,6 +6,8 @@ npm install -g pake-cli
 
 如果安装失败提示没有权限，请参考该贴解决：[链接](https://gist.github.com/Giancarlos/d087f8a9e6516716da98ad0c0f5a8f58)。
 
+此外，请确保你使用的是正确的 Node.js 版本（`^14.13 || >=16.0.0`）。如果你在使用 [nvm](https://github.com/nvm-sh/nvm) 进行 Node.js 版本管理，可以尝试在项目的目录下运行 `nvm use`，就会拿到正确的版本；其他一众 Node.js 版本工具，比如 [fnm](https://github.com/Schniz/fnm)、[tj/n](https://github.com/tj/n) 应该也有类似的功能。
+
 **尽量不要使用 `sudo` 权限**。 如果实在要用sudo，请手动安装rust到系统环境。Mac可以用brew命令安装，Linux如Ubuntu可以用apt命令安装。
 
 

--- a/bin/README_EN.md
+++ b/bin/README_EN.md
@@ -6,6 +6,9 @@ npm install -g pake-cli
 
 If the installation fails and you are prompted that you do not have permission, please see this [website](https://gist.github.com/Giancarlos/d087f8a9e6516716da98ad0c0f5a8f58) .
 
+
+Also make sure that you're using a correct Node.js version (`^14.13 || >=16.0.0`). If you're using [nvm](https://github.com/nvm-sh/nvm) for Node.js version management you may run `nvm use` from the root folder of the project and the correct version will be picked up. Other Node.js version management tools, such as [fnm](https://github.com/Schniz/fnm) and [tj/n](https://github.com/tj/n), should also have similar feature.
+
 **try not to use `sudo` permissions**, If you must use sudo, you need install rust in you system environment. For Mac, you can use brew to install it. For Linux like Ubuntu, you need apt to install it.
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "pake-cli",
   "version": "0.1.3",
   "description": "🤱🏻 很简单的用 Rust 打包网页生成很小的桌面 App 🤱🏻 A simple way to make any web page a desktop application using Rust.",
+  "engines": {
+    "node": "^14.13 || >=16.0.0"
+  },
   "bin": {
     "pake": "./cli.js"
   },


### PR DESCRIPTION
Fix: #177

## 其他

### 关于 `packageManager` 的一些想法：

虽然我们的文档中都是在用 npm 做示例，不过考虑到使用 npm、yarn 又或者是 pnpm 是个人喜好， 暂时不对`packageManager` 做限制了。

特别是 Pake 仓库曾经一度还上传过 *yarn.lock* 和 *package-lock.json*，说明在之前，我们对用户使用什么包管理工具也是不做强制要求的。