### PR TITLE
fix: correct github action linux build

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -120,8 +120,8 @@ do
 
     if [[ "$OSTYPE" =~ ^linux ]]; then
         npm run tauri build
-        mv src-tauri/target/release/bundle/deb/${package_prefix}-"${package_name}"*.deb output/linux/"${package_title}"_`arch`.deb
-        mv src-tauri/target/release/bundle/appimage/${package_prefix}-"${package_name}"*.AppImage output/linux/"${package_title}"_`arch`.AppImage
+        mv src-tauri/target/release/bundle/deb/*.deb output/linux/
+        mv src-tauri/target/release/bundle/appimage/*.AppImage output/linux/
         echo clear cache
         rm src-tauri/target/release
         rm -rf src-tauri/target/release/bundle


### PR DESCRIPTION
当前使用 Action 进行 linux build 会出现以下问题：https://github.com/tw93/Pake/discussions/315

本PR修改
```bash
mv src-tauri/target/release/bundle/deb/${package_prefix}-"${package_name}"*.deb output/linux/"${package_title}"_`arch`.deb
mv src-tauri/target/release/bundle/appimage/${package_prefix}-"${package_name}"*.AppImage output/linux/"${package_title}"_`arch`.AppImage
```
为
```bash
mv src-tauri/target/release/bundle/deb/*.deb output/linux/
mv src-tauri/target/release/bundle/appimage/*.AppImage output/linux/
```
以解决此问题。