### PR TITLE
:art: (app) 用 PlatformSpecific 代替到处判断系统

### DIFF
--- a/src-tauri/src/app/config.rs
+++ b/src-tauri/src/app/config.rs
@@ -12,18 +12,36 @@ pub struct WindowConfig {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct UserAgent {
-    pub macos: String,
-    pub linux: String,
-    pub windows: String,
+pub struct PlatformSpecific<T> {
+    pub macos: T,
+    pub linux: T,
+    pub windows: T,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct FunctionON {
-    pub macos: bool,
-    pub linux: bool,
-    pub windows: bool,
+impl<T> PlatformSpecific<T> {
+    pub const fn get(&self) -> &T {
+        #[cfg(target_os = "macos")]
+        let platform = &self.macos;
+        #[cfg(target_os = "linux")]
+        let platform = &self.linux;
+        #[cfg(target_os = "windows")]
+        let platform = &self.windows;
+
+        platform
+    }
 }
+
+impl<T> PlatformSpecific<T>
+where
+    T: Copy,
+{
+    pub const fn copied(&self) -> T {
+        *self.get()
+    }
+}
+
+pub type UserAgent = PlatformSpecific<String>;
+pub type FunctionON = PlatformSpecific<bool>;
 
 #[derive(Debug, Deserialize)]
 pub struct PakeConfig {
@@ -35,23 +53,11 @@ pub struct PakeConfig {
 
 impl PakeConfig {
     pub fn show_menu(&self) -> bool {
-        #[cfg(target_os = "macos")]
-        let menu_status = self.menu.macos;
-        #[cfg(target_os = "linux")]
-        let menu_status = self.menu.linux;
-        #[cfg(target_os = "windows")]
-        let menu_status = self.menu.windows;
-        menu_status
+        self.menu.copied()
     }
 
     #[cfg(not(target_os = "macos"))]
     pub fn show_system_tray(&self) -> bool {
-        #[cfg(target_os = "macos")]
-        let tray_status = self.system_tray.macos;
-        #[cfg(target_os = "linux")]
-        let tray_status = self.system_tray.linux;
-        #[cfg(target_os = "windows")]
-        let tray_status = self.system_tray.windows;
-        tray_status
+        self.menu.copied()
     }
 }

--- a/src-tauri/src/app/window.rs
+++ b/src-tauri/src/app/window.rs
@@ -11,17 +11,12 @@ pub fn get_window(app: &mut App, config: PakeConfig, _data_dir: PathBuf) -> Wind
         .first()
         .expect("At least one window configuration is required");
 
-    #[cfg(target_os = "macos")]
-    let user_agent = config.user_agent.macos.as_str();
-    #[cfg(target_os = "linux")]
-    let user_agent = config.user_agent.linux.as_str();
-    #[cfg(target_os = "windows")]
-    let user_agent = config.user_agent.windows.as_str();
+    let user_agent = config.user_agent.get();
 
     let url = match window_config.url_type.as_str() {
         "web" => WindowUrl::App(window_config.url.parse().unwrap()),
         "local" => WindowUrl::App(PathBuf::from(&window_config.url)),
-        _ => panic!("url type only can be web or local"),
+        _ => panic!("url type can only be web or local"),
     };
 
     let mut window_builder = WindowBuilder::new(app, "pake", url)

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -34,4 +34,3 @@ pub fn get_data_dir(_tauri_config: Config) -> PathBuf {
         PathBuf::new()
     }
 }
-


### PR DESCRIPTION
以往需要跨平台不同值时，我们都是到处进行 cfg-target 判断。

由于代码片段都是重复的，因此这个 commit 把所有相关的跨平台结构
全部整合在一个结构 (PlatformSpecific) 内，这样除了更容易制造
规范的接口，还可以提升维护的效率（而不用到处修改相关的判断逻辑）。
