### PR TITLE
fix(event): Remove command + arrow right navigation

### DIFF
--- a/src-tauri/src/inject/event.js
+++ b/src-tauri/src/inject/event.js
@@ -1,6 +1,10 @@
 const shortcuts = {
   ArrowUp: () => scrollTo(0, 0),
   ArrowDown: () => scrollTo(0, document.body.scrollHeight),
+  // Don't use command + ArrowLeft or command + ArrowRight
+  // When editing text in page, it causes unintended page navigation.
+  // ArrowLeft: () => window.history.back(),
+  // ArrowRight: () => window.history.forward(),
   '[': () => window.history.back(),
   ']': () => window.history.forward(),
   r: () => window.location.reload(),

--- a/src-tauri/src/inject/event.js
+++ b/src-tauri/src/inject/event.js
@@ -1,8 +1,6 @@
 const shortcuts = {
   ArrowUp: () => scrollTo(0, 0),
   ArrowDown: () => scrollTo(0, document.body.scrollHeight),
-  ArrowLeft: () => window.history.back(),
-  ArrowRight: () => window.history.forward(),
   '[': () => window.history.back(),
   ']': () => window.history.forward(),
   r: () => window.location.reload(),


### PR DESCRIPTION
之前就是因为 command + left 和 right 会导致错误地跳转，才将其转换为 command + [ 和 command + ] 跳转的