### PR TITLE
fix download judgement.

### DIFF
--- a/src-tauri/src/inject/event.js
+++ b/src-tauri/src/inject/event.js
@@ -127,16 +127,16 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
 
+      let filename = anchorElement.download ? anchorElement.download : getFilenameFromUrl(absoluteUrl)
       // Process download links for Rust to handle.
-      if (
-        /\.[a-zA-Z0-9]+$/i.test(removeUrlParameters(absoluteUrl)) &&
-        !externalDownLoadLink()
+      if ((anchorElement.download /* download attribute */ || e.metaKey /* Click anchor with meta key pressed could download any kind of resource. */)
+        && !externalDownLoadLink()
       ) {
         e.preventDefault();
         invoke('download_file', {
           params: {
             url: absoluteUrl,
-            filename: getFilenameFromUrl(absoluteUrl),
+            filename,
           },
         });
       }


### PR DESCRIPTION
1. support download attribute of anchor.
2. click link with meta key pressed to download any link, instead of judging the suffix which may block the normal page likes xxx.html, could be also not able to download files implied by the response headers.