### PR TITLE
support setting the installer language

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -211,6 +211,14 @@ Specify the system tray icon. This is only effective when the system tray is ena
 --system-tray-icon <path>
 ```
 
+#### [installer-language]
+
+Set the Windows Installer language. Options include `zh-CN`, `ja-JP`, More at [Tauri Document](https://tauri.app/zh-cn/v1/guides/building/windows/#internationalization). Default is `en-US`.
+
+```shell
+--installer-language <language>
+```
+
 #### [use-local-file]
 
 Enable recursive copying. When the URL is a local file path, enabling this option will copy the folder containing the file specified in the URL, as well as all sub-files, to the Pake static folder. This is disabled by default.

--- a/bin/README_CN.md
+++ b/bin/README_CN.md
@@ -212,6 +212,14 @@ Linux，默认为 `all`。
 --system-tray-icon <path>
 ```
 
+#### [installer-language]
+
+设置 Windows 安装包语言。支持 `zh-CN`、`ja-JP`，更多在 [Tauri 文档](https://tauri.app/zh-cn/v1/guides/building/windows/#internationalization)。默认为 `en-US`。
+
+```shell
+--installer-language <language>
+```
+
 #### [use-local-file]
 
 当 `url` 为本地文件路径时，如果启用此选项，则会递归地将 `url` 路径文件所在的文件夹及其所有子文件复

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -52,6 +52,9 @@ program
   .addOption(
     new Option('--system-tray-icon <string>', 'Custom system tray icon').default(DEFAULT.systemTrayIcon).hideHelp(),
   )
+  .addOption(
+    new Option('--installer-language <string>', 'Installer language').default(DEFAULT.installerLanguage).hideHelp(),
+  )
   .version(packageJson.version, '-v, --version', 'Output the current version')
   .action(async (url: string, options: PakeCliOptions) => {
     await checkUpdateTips();

--- a/bin/defaults.ts
+++ b/bin/defaults.ts
@@ -19,6 +19,7 @@ export const DEFAULT_PAKE_OPTIONS: PakeCliOptions = {
   debug: false,
   inject: [],
   safeDomain: [],
+  installerLanguage: 'en-US',
 };
 
 // Just for cli development

--- a/bin/helpers/merge.ts
+++ b/bin/helpers/merge.ts
@@ -45,7 +45,9 @@ export async function mergeConfig(url: string, options: PakeAppOptions, tauriCon
 
   tauriConf.package.productName = name;
   tauriConf.tauri.bundle.identifier = identifier;
-  tauriConf.tauri.bundle.windows.wix.language[0] = installerLanguage
+  if (platform == "win32") {
+    tauriConf.tauri.bundle.windows.wix.language[0] = installerLanguage;
+  }
 
   //Judge the type of URL, whether it is a file or a website.
   const pathExists = await fsExtra.pathExists(url);

--- a/bin/helpers/merge.ts
+++ b/bin/helpers/merge.ts
@@ -25,6 +25,7 @@ export async function mergeConfig(url: string, options: PakeAppOptions, tauriCon
     resizable = true,
     inject,
     safeDomain,
+    installerLanguage,
   } = options;
 
   const { platform } = process;
@@ -44,6 +45,7 @@ export async function mergeConfig(url: string, options: PakeAppOptions, tauriCon
 
   tauriConf.package.productName = name;
   tauriConf.tauri.bundle.identifier = identifier;
+  tauriConf.tauri.bundle.windows.wix.language[0] = installerLanguage
 
   //Judge the type of URL, whether it is a file or a website.
   const pathExists = await fsExtra.pathExists(url);

--- a/bin/types.ts
+++ b/bin/types.ts
@@ -59,6 +59,9 @@ export interface PakeCliOptions {
 
   /* the domain that can use ipc or tauri javascript sdk */
   safeDomain: string[];
+
+  // Installer language, valid for Windows users, default is en-US
+  installerLanguage: string;
 }
 
 export interface PakeAppOptions extends PakeCliOptions {

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -492,7 +492,9 @@ async function mergeConfig(url, options, tauriConf) {
     Object.assign(tauriConf.pake.windows[0], { url, ...tauriConfWindowOptions });
     tauriConf.package.productName = name;
     tauriConf.tauri.bundle.identifier = identifier;
-    tauriConf.tauri.bundle.windows.wix.language[0] = installerLanguage;
+    if (platform == "win32") {
+        tauriConf.tauri.bundle.windows.wix.language[0] = installerLanguage;
+    }
     //Judge the type of URL, whether it is a file or a website.
     const pathExists = await fsExtra.pathExists(url);
     if (pathExists) {

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -476,7 +476,7 @@ async function combineFiles(files, output) {
 }
 
 async function mergeConfig(url, options, tauriConf) {
-    const { width, height, fullscreen, hideTitleBar, alwaysOnTop, disabledWebShortcuts, activationShortcut, userAgent, showSystemTray, systemTrayIcon, useLocalFile, identifier, name, resizable = true, inject, safeDomain, } = options;
+    const { width, height, fullscreen, hideTitleBar, alwaysOnTop, disabledWebShortcuts, activationShortcut, userAgent, showSystemTray, systemTrayIcon, useLocalFile, identifier, name, resizable = true, inject, safeDomain, installerLanguage, } = options;
     const { platform } = process;
     // Set Windows parameters.
     const tauriConfWindowOptions = {
@@ -492,6 +492,7 @@ async function mergeConfig(url, options, tauriConf) {
     Object.assign(tauriConf.pake.windows[0], { url, ...tauriConfWindowOptions });
     tauriConf.package.productName = name;
     tauriConf.tauri.bundle.identifier = identifier;
+    tauriConf.tauri.bundle.windows.wix.language[0] = installerLanguage;
     //Judge the type of URL, whether it is a file or a website.
     const pathExists = await fsExtra.pathExists(url);
     if (pathExists) {
@@ -845,6 +846,7 @@ const DEFAULT_PAKE_OPTIONS = {
     debug: false,
     inject: [],
     safeDomain: [],
+    installerLanguage: 'en-US',
 };
 
 async function checkUpdateTips() {
@@ -1041,6 +1043,7 @@ program
     .hideHelp())
     .addOption(new Option('--show-system-tray', 'Show system tray in app').default(DEFAULT_PAKE_OPTIONS.showSystemTray).hideHelp())
     .addOption(new Option('--system-tray-icon <string>', 'Custom system tray icon').default(DEFAULT_PAKE_OPTIONS.systemTrayIcon).hideHelp())
+    .addOption(new Option('--installer-language <string>', 'Installer language').default(DEFAULT_PAKE_OPTIONS.installerLanguage).hideHelp())
     .version(packageJson.version, '-v, --version', 'Output the current version')
     .action(async (url, options) => {
     await checkUpdateTips();


### PR DESCRIPTION
https://github.com/tw93/Pake/issues/711

支持 cli 参数 `--installer-language zh-CN` 设置安装包语言，完整的命令如下：

```
pake https://weekly.tw93.fun --name Weekly --hide-title-bar --installer-language zh-CN
```

支持的语言参考：<https://tauri.app/zh-cn/v1/guides/building/windows#internationalization>

设置中文效果：

```shell
--installer-language zh-CN
```

![zh-CN](https://github.com/tw93/Pake/assets/17895104/d197f53b-4975-4ce3-80cd-8cb89f2afa9f)

设置日语效果：

```shell
--installer-language ja-JP
```

![ja-JP](https://github.com/tw93/Pake/assets/17895104/9a9cca84-1f86-4e68-80a2-cfa15f73d27d)
