### PR TITLE
Use host instead of hostname for proper matching against the window location

### DIFF
--- a/src-tauri/src/inject/event.js
+++ b/src-tauri/src/inject/event.js
@@ -176,7 +176,7 @@ document.addEventListener('DOMContentLoaded', () => {
             // case: download from dataURL -> convert dataURL ->
           } else if (url.startsWith('data:')) {
             downloadFromDataUri(url, filename);
-          } else if (isDownloadLink(url) || anchorEle.hostname !== window.location.host) {
+          } else if (isDownloadLink(url) || anchorEle.host !== window.location.host) {
             handleExternalLink(e, url);
           }
         },


### PR DESCRIPTION
## Issue
When using hosts with ports all links to the current host are considered external links.

## Fix
Match host with host instead of hostname with host so links with ports will not be considered external links.