### PR TITLE
feat: allow names with spaces (Windows & macOS)

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -22,7 +22,9 @@ program.addHelpText('beforeAll', logo).usage(`[url] [options]`).showHelpAfterErr
 
 program
   .argument('[url]', 'The web URL you want to package', validateUrlInput)
-  .option('--name <string>', 'Application name')
+  .option('--name <string...>', 'Application name', (value, previous) => {
+    return previous === undefined ? value : `${previous} ${value}`
+  }) // Refer to https://github.com/tj/commander.js#custom-option-processing, turn string array into a string connected with spaces.
   .option('--icon <string>', 'Application icon', DEFAULT.icon)
   .option('--width <number>', 'Window width', validateNumberInput, DEFAULT.width)
   .option('--height <number>', 'Window height', validateNumberInput, DEFAULT.height)

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -22,9 +22,16 @@ program.addHelpText('beforeAll', logo).usage(`[url] [options]`).showHelpAfterErr
 
 program
   .argument('[url]', 'The web URL you want to package', validateUrlInput)
+  // Refer to https://github.com/tj/commander.js#custom-option-processing, turn string array into a string connected with custom connectors.
+  // If the platform is Linux, use `-` as the connector, and convert all characters to lowercase.
+  // For example, Google Translate will become google-translate.
   .option('--name <string...>', 'Application name', (value, previous) => {
-    return previous === undefined ? value : `${previous} ${value}`
-  }) // Refer to https://github.com/tj/commander.js#custom-option-processing, turn string array into a string connected with spaces.
+    const platform = process.platform
+    const connector = platform === 'linux' ? '-' : ' '
+    const name = previous === undefined ? value : `${previous}${connector}${value}`
+    
+    return platform === 'linux' ? name.toLowerCase() : name
+  })
   .option('--icon <string>', 'Application icon', DEFAULT.icon)
   .option('--width <number>', 'Window width', validateNumberInput, DEFAULT.width)
   .option('--height <number>', 'Window height', validateNumberInput, DEFAULT.height)

--- a/bin/options/index.ts
+++ b/bin/options/index.ts
@@ -13,8 +13,8 @@ function resolveAppName(name: string, platform: NodeJS.Platform): string {
 
 function isValidName(name: string, platform: NodeJS.Platform): boolean {
   const platformRegexMapping: PlatformMap = {
-    linux: /^[a-z0-9]+(-[a-z0-9]+)*$/,
-    default: /^[a-zA-Z0-9]+([-a-zA-Z0-9])*$/,
+    linux: /^[a-z0-9][a-z0-9-]*$/,
+    default: /^[a-zA-Z0-9][a-zA-Z0-9- ]*$/,
   };
   const reg = platformRegexMapping[platform] || platformRegexMapping.default;
   return !!name && reg.test(name);
@@ -34,8 +34,8 @@ export default async function handleOptions(options: PakeCliOptions, url: string
   }
 
   if (!isValidName(name, platform)) {
-    const LINUX_NAME_ERROR = `✕ name should only include lowercase letters, numbers, and dashes, and must contain at least one lowercase letter. Examples: com-123-xxx, 123pan, pan123, weread, we-read.`;
-    const DEFAULT_NAME_ERROR = `✕ Name should only include letters and numbers, and dashes (dashes must not at the beginning), and must contain at least one letter. Examples: 123pan, 123Pan, Pan123, weread, WeRead, WERead, we-read.`;
+    const LINUX_NAME_ERROR = `✕ Name should only include lowercase letters, numbers, and dashes (not leading dashes), and must contain at least one lowercase letter or number. Examples: com-123-xxx, 123pan, pan123, weread, we-read.`;
+    const DEFAULT_NAME_ERROR = `✕ Name should only include letters, numbers, dashes, and spaces (not leading dashes and spaces), and must contain at least one letter or number. Examples: 123pan, 123Pan, Pan123, weread, WeRead, WERead, we-read, We Read.`;
     const errorMsg = platform === 'linux' ? LINUX_NAME_ERROR : DEFAULT_NAME_ERROR;
     logger.error(errorMsg);
     if (isActions) {

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -960,9 +960,15 @@ ${green('|_|   \\__,_|_|\\_\\___|  can turn any webpage into a desktop app with 
 program.addHelpText('beforeAll', logo).usage(`[url] [options]`).showHelpAfterError();
 program
     .argument('[url]', 'The web URL you want to package', validateUrlInput)
+    // Refer to https://github.com/tj/commander.js#custom-option-processing, turn string array into a string connected with custom connectors.
+    // If the platform is Linux, use `-` as the connector, and convert all characters to lowercase.
+    // For example, Google Translate will become google-translate.
     .option('--name <string...>', 'Application name', (value, previous) => {
-    return previous === undefined ? value : `${previous} ${value}`;
-}) // Refer to https://github.com/tj/commander.js#custom-option-processing, turn string array into a string connected with spaces.
+    const platform = process.platform;
+    const connector = platform === 'linux' ? '-' : ' ';
+    const name = previous === undefined ? value : `${previous}${connector}${value}`;
+    return platform === 'linux' ? name.toLowerCase() : name;
+})
     .option('--icon <string>', 'Application icon', DEFAULT_PAKE_OPTIONS.icon)
     .option('--width <number>', 'Window width', validateNumberInput, DEFAULT_PAKE_OPTIONS.width)
     .option('--height <number>', 'Window height', validateNumberInput, DEFAULT_PAKE_OPTIONS.height)

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -891,8 +891,8 @@ function resolveAppName(name, platform) {
 }
 function isValidName(name, platform) {
     const platformRegexMapping = {
-        linux: /^[a-z0-9]+(-[a-z0-9]+)*$/,
-        default: /^[a-zA-Z0-9]+([-a-zA-Z0-9])*$/,
+        linux: /^[a-z0-9][a-z0-9-]*$/,
+        default: /^[a-zA-Z0-9][a-zA-Z0-9- ]*$/,
     };
     const reg = platformRegexMapping[platform] || platformRegexMapping.default;
     return !!name && reg.test(name);
@@ -909,8 +909,8 @@ async function handleOptions(options, url) {
         name = namePrompt || defaultName;
     }
     if (!isValidName(name, platform)) {
-        const LINUX_NAME_ERROR = `✕ name should only include lowercase letters, numbers, and dashes, and must contain at least one lowercase letter. Examples: com-123-xxx, 123pan, pan123, weread, we-read.`;
-        const DEFAULT_NAME_ERROR = `✕ Name should only include letters and numbers, and dashes (dashes must not at the beginning), and must contain at least one letter. Examples: 123pan, 123Pan, Pan123, weread, WeRead, WERead, we-read.`;
+        const LINUX_NAME_ERROR = `✕ Name should only include lowercase letters, numbers, and dashes (not leading dashes), and must contain at least one lowercase letter or number. Examples: com-123-xxx, 123pan, pan123, weread, we-read.`;
+        const DEFAULT_NAME_ERROR = `✕ Name should only include letters, numbers, dashes, and spaces (not leading dashes and spaces), and must contain at least one letter or number. Examples: 123pan, 123Pan, Pan123, weread, WeRead, WERead, we-read, We Read.`;
         const errorMsg = platform === 'linux' ? LINUX_NAME_ERROR : DEFAULT_NAME_ERROR;
         logger.error(errorMsg);
         if (isActions) {
@@ -960,7 +960,9 @@ ${green('|_|   \\__,_|_|\\_\\___|  can turn any webpage into a desktop app with 
 program.addHelpText('beforeAll', logo).usage(`[url] [options]`).showHelpAfterError();
 program
     .argument('[url]', 'The web URL you want to package', validateUrlInput)
-    .option('--name <string>', 'Application name')
+    .option('--name <string...>', 'Application name', (value, previous) => {
+    return previous === undefined ? value : `${previous} ${value}`;
+}) // Refer to https://github.com/tj/commander.js#custom-option-processing, turn string array into a string connected with spaces.
     .option('--icon <string>', 'Application icon', DEFAULT_PAKE_OPTIONS.icon)
     .option('--width <number>', 'Window width', validateNumberInput, DEFAULT_PAKE_OPTIONS.width)
     .option('--height <number>', 'Window height', validateNumberInput, DEFAULT_PAKE_OPTIONS.height)


### PR DESCRIPTION
Close #873

This PR updates the name option to accept names with spaces. For example, you can use the below command to generate the app:

```sh
pake https://translate.google.com/ --name Google Translate --hide-title-bar
```

However, I didn't update the Linux platform's name pattern because I saw some specific rules (only lowercase letters) in the regex. @tw93 Can the Linux app name contain spaces?