### PR TITLE
Fix: TypeError when using --inject with comma-separated file paths

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -30,7 +30,12 @@ program
   .option('--fullscreen', 'Start in full screen', DEFAULT.fullscreen)
   .option('--hide-title-bar', 'For Mac, hide title bar', DEFAULT.hideTitleBar)
   .option('--multi-arch', 'For Mac, both Intel and M1', DEFAULT.multiArch)
-  .option('--inject <url...>', 'Injection of .js or .css files', DEFAULT.inject)
+  .option(
+    '--inject <./style.css,./script.js,...>',
+    'Injection of .js or .css files',
+    (val, previous) => (val ? val.split(',').map(item => item.trim()) : DEFAULT.inject),
+    DEFAULT.inject,
+  )
   .option('--debug', 'Debug build and more output', DEFAULT.debug)
   .addOption(new Option('--proxy-url <url>', 'Proxy URL for all network requests').default(DEFAULT_PAKE_OPTIONS.proxyUrl).hideHelp())
   .addOption(new Option('--user-agent <string>', 'Custom user agent').default(DEFAULT.userAgent).hideHelp())

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -778,7 +778,6 @@ const DEFAULT_PAKE_OPTIONS = {
     height: 780,
     width: 1200,
     fullscreen: false,
-    resizable: true,
     hideTitleBar: false,
     alwaysOnTop: false,
     appVersion: '1.0.0',
@@ -977,7 +976,7 @@ program
     .option('--fullscreen', 'Start in full screen', DEFAULT_PAKE_OPTIONS.fullscreen)
     .option('--hide-title-bar', 'For Mac, hide title bar', DEFAULT_PAKE_OPTIONS.hideTitleBar)
     .option('--multi-arch', 'For Mac, both Intel and M1', DEFAULT_PAKE_OPTIONS.multiArch)
-    .option('--inject <url>', 'Injection of .js or .css files', DEFAULT_PAKE_OPTIONS.inject)
+    .option('--inject <./style.css,./script.js,...>', 'Injection of .js or .css files', (val, previous) => (val ? val.split(',').map(item => item.trim()) : DEFAULT_PAKE_OPTIONS.inject), DEFAULT_PAKE_OPTIONS.inject)
     .option('--debug', 'Debug build and more output', DEFAULT_PAKE_OPTIONS.debug)
     .addOption(new Option('--proxy-url <url>', 'Proxy URL for all network requests').default(DEFAULT_PAKE_OPTIONS.proxyUrl).hideHelp())
     .addOption(new Option('--user-agent <string>', 'Custom user agent').default(DEFAULT_PAKE_OPTIONS.userAgent).hideHelp())


### PR DESCRIPTION
This PR fixes an issue where using the --inject option with comma-separated file paths (e.g. --inject file1.js,file2.css) causes a TypeError.

Root Cause
The problem occurs because the inject parameter is received as a string, but the code attempts to call Array.every() on it, resulting in a TypeError.

Solution
This PR adds a custom option processor for the --inject option that automatically splits the comma-separated string into an array. This ensures that when the option value reaches the validation code, it's already in the expected array format.








## Related Issues
fixed #914 

# Problem
When using the `--inject` option with comma-separated file paths, the application throws a TypeError because Commander.js passes the option value as a string, but the code expects an array when calling the `.every()` method.

 ```
➜  workspace pake https://chat.kittizz.com --name ChatKT --icon /Users/kittizz/workspace/pake/chat-kt/chatkt.ico --hide-title-bar --inject "/Users/kittizz/workspace/pake/chat-kt/style.css,/Users/kittizz/workspace/pake/chat-kt/script.js" --debug
PakeAppOptions {
  icon: '/Users/kittizz/workspace/pake/chat-kt/chatkt.ico',
  width: 1200,
  height: 780,
  useLocalFile: false,
  fullscreen: false,
  hideTitleBar: true,
  multiArch: false,
  inject: '/Users/kittizz/workspace/pake/chat-kt/style.css,/Users/kittizz/workspace/pake/chat-kt/script.js',
  debug: true,
  proxyUrl: '',
  userAgent: '',
  targets: 'deb',
  appVersion: '1.0.0',
  alwaysOnTop: false,
  darkMode: false,
  disabledWebShortcuts: false,
  activationShortcut: '',
  showSystemTray: false,
  systemTrayIcon: '',
  installerLanguage: 'en-US',
  name: 'ChatKT',
  identifier: 'com.pake.61f97b'
}
www.npmjs.com latency is 8 ms
✶ Installing package...

up to date, audited 223 packages in 570ms

73 packages are looking for funding
  run `npm fund` for details

✔ Package installed!
✼ macOS icon must be .icns type., but you give .ico
✼ Icon will remain as default.
file:///Users/kittizz/Library/pnpm/global/5/.pnpm/pake-cli@3.1.1/node_modules/pake-cli/dist/cli.js:572
        if (!inject.every(item => item.endsWith('.css') || item.endsWith('.js'))) {
                    ^

TypeError: inject.every is not a function
    at mergeConfig (file:///Users/kittizz/Library/pnpm/global/5/.pnpm/pake-cli@3.1.1/node_modules/pake-cli/dist/cli.js:572:21)
    at async MacBuilder.buildAndCopy (file:///Users/kittizz/Library/pnpm/global/5/.pnpm/pake-cli@3.1.1/node_modules/pake-cli/dist/cli.js:656:9)
    at async MacBuilder.build (file:///Users/kittizz/Library/pnpm/global/5/.pnpm/pake-cli@3.1.1/node_modules/pake-cli/dist/cli.js:649:9)
    at async Command.<anonymous> (file:///Users/kittizz/Library/pnpm/global/5/.pnpm/pake-cli@3.1.1/node_modules/pake-cli/dist/cli.js:1013:5)

Node.js v22.14.0
```

# Testing
test css,js path 
```
➜  Pake git:(fix-cli-inject) ✗ node cli.js https://chat.kittizz.com --name ChatKT --icon /Users/kittizz/workspace/pake/chat-kt/chatkt.ico --hide-title-bar --inject "/Users/kittizz/workspace/pake/chat-kt/style.css,/Users/kittizz/workspace/pake/chat-kt/script.js" --debug
PakeAppOptions {
  icon: '/Users/kittizz/workspace/pake/chat-kt/chatkt.ico',
  width: 1200,
  height: 780,
  useLocalFile: false,
  fullscreen: false,
  hideTitleBar: true,
  multiArch: false,
  inject: [
    '/Users/kittizz/workspace/pake/chat-kt/style.css',
    '/Users/kittizz/workspace/pake/chat-kt/script.js'
  ],

```

test only js
```
➜  Pake git:(fix-cli-inject) ✗ node cli.js https://chat.kittizz.com --name ChatKT --icon /Users/kittizz/workspace/pake/chat-kt/chatkt.ico --hide-title-bar --inject "/Users/kittizz/workspace/pake/chat-kt/style.js" --debug        
PakeAppOptions {
  icon: '/Users/kittizz/workspace/pake/chat-kt/chatkt.ico',
  width: 1200,
  height: 780,
  useLocalFile: false,
  fullscreen: false,
  hideTitleBar: true,
  multiArch: false,
  inject: [ '/Users/kittizz/workspace/pake/chat-kt/style.js' ],
```

test no inject
```
➜  Pake git:(fix-cli-inject) ✗ node cli.js https://chat.kittizz.com --name ChatKT --icon /Users/kittizz/workspace/pake/chat-kt/chatkt.ico --hide-title-bar  --debug                                                                                                          
PakeAppOptions {
  icon: '/Users/kittizz/workspace/pake/chat-kt/chatkt.ico',
  width: 1200,
  height: 780,
  useLocalFile: false,
  fullscreen: false,
  hideTitleBar: true,
  multiArch: false,
  inject: [],

```