### PR TITLE
Fix error when using --inject

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -977,7 +977,7 @@ program
     .option('--fullscreen', 'Start in full screen', DEFAULT_PAKE_OPTIONS.fullscreen)
     .option('--hide-title-bar', 'For Mac, hide title bar', DEFAULT_PAKE_OPTIONS.hideTitleBar)
     .option('--multi-arch', 'For Mac, both Intel and M1', DEFAULT_PAKE_OPTIONS.multiArch)
-    .option('--inject <url>', 'Injection of .js or .css files', DEFAULT_PAKE_OPTIONS.inject)
+    .option('--inject <url...>', 'Injection of .js or .css files', DEFAULT_PAKE_OPTIONS.inject)
     .option('--debug', 'Debug build and more output', DEFAULT_PAKE_OPTIONS.debug)
     .addOption(new Option('--proxy-url <url>', 'Proxy URL for all network requests').default(DEFAULT_PAKE_OPTIONS.proxyUrl).hideHelp())
     .addOption(new Option('--user-agent <string>', 'Custom user agent').default(DEFAULT_PAKE_OPTIONS.userAgent).hideHelp())


### PR DESCRIPTION
the error example:

file:///home/remi/.node/lib/node_modules/pake-cli/dist/cli.js:572
        if (!inject.every(item => item.endsWith('.css') || item.endsWith('.js'))) {
                    ^

TypeError: inject.every is not a function
    at mergeConfig (file:///home/remi/.node/lib/node_modules/pake-cli/dist/cli.js:572:21)
    at async LinuxBuilder.buildAndCopy (file:///home/remi/.node/lib/node_modules/pake-cli/dist/cli.js:656:9)
    at async LinuxBuilder.build (file:///home/remi/.node/lib/node_modules/pake-cli/dist/cli.js:748:17)
    at async Command.<anonymous> (file:///home/remi/.node/lib/node_modules/pake-cli/dist/cli.js:1013:5)

Node.js v18.19.1
