### PR TITLE
fix: correct script path typo (add missing 's'), update pake-cli.yaml

### DIFF
--- a/.github/workflows/pake-cli.yaml
+++ b/.github/workflows/pake-cli.yaml
@@ -144,7 +144,7 @@ jobs:
       - name: Build with pake-cli
         timeout-minutes: 15
         run: |
-          node ./script/github-action-build.js
+          node ./scripts/github-action-build.js
         env:
           URL: ${{ inputs.url }}
           NAME: ${{ inputs.name }}


### PR DESCRIPTION
- **When running "Build App With Pake CLI" GitHub Action, it throws `MODULE_NOT_FOUND` because path `script/` is missing an "s", fixed to `scripts/`**
- description:
- encountered an error while running the "Build App With Pake CLI" workflow
- searching through the repository files, I located the relevant file at: [Pake/scripts/github-action-build.js at bf12d85dc59dab913dd893873e3f49eb59ed91c0 · tw93/Pake](https://github.com/tw93/Pake/blob/bf12d85dc59dab913dd893873e3f49eb59ed91c0/scripts/github-action-build.js)
- Upon verification, the correct path to this file within the repository is `scripts/github-action-build.js`.

- error message:
```
Run node ./script/github-action-build.js
node:internal/modules/cjs/loader:1368
  throw err;
  ^

Error: Cannot find module 'D:\a\Pake\Pake\script\github-action-build.js'

错误：找不到模块 'D:\a\Pake\Pake\script\github-action-build.js'
    at Function._resolveFilename (node:internal/modules/cjs/loader:1365:15)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1021:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1026:22)
    at Function._load (node:internal/modules/cjs/loader:1175:37)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:171:5)
    at node:internal/main/run_main_module:36:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v22.18.0
Error: Process completed with exit code 1.
```