### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/pake-cli.yaml
+++ b/.github/workflows/pake-cli.yaml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -165,7 +165,7 @@ jobs:
 
       - name: Upload DMG (macOS)
         if: runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.name }}-macOS
           path: ${{ inputs.name }}.dmg
@@ -173,7 +173,7 @@ jobs:
 
       - name: Upload DEB (Linux)
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.name }}-Linux-deb
           path: ${{ inputs.name }}.deb
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload AppImage (Linux)
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.name }}-Linux-AppImage
           path: ${{ inputs.name }}.AppImage
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload MSI (Windows)
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.name }}-Windows
           path: ${{ inputs.name }}.msi

--- a/.github/workflows/quality-and-test.yml
+++ b/.github/workflows/quality-and-test.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         working-directory: src-tauri
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-env
@@ -80,7 +80,7 @@ jobs:
       - uses: rui314/setup-mold@v1
 
       - name: Cache cargo-hack
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cargo-hack-cache
         with:
           path: ~/.cargo/bin/cargo-hack
@@ -107,7 +107,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Build Environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       apps_config: ${{ steps.read-apps-config.outputs.apps_config }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get Apps Config
         id: read-apps-config
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js Environment
         uses: ./.github/actions/setup-env
@@ -59,7 +59,7 @@ jobs:
         run: pnpm run cli:build
 
       - name: Upload CLI Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pake-cli-dist
           path: dist/
@@ -91,7 +91,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -105,7 +105,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -114,7 +114,7 @@ jobs:
             type=sha
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/single-app.yaml
+++ b/.github/workflows/single-app.yaml
@@ -73,7 +73,7 @@ jobs:
             rust: stable
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -86,7 +86,7 @@ jobs:
           mode: build
 
       - name: Download CLI Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: pake-cli-dist
           path: dist
@@ -218,7 +218,7 @@ jobs:
           git checkout -- src-tauri/Cargo.lock
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.title }}-${{ matrix.build }}
           path: output/*/*.*

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -52,7 +52,7 @@ jobs:
             </g>
 
       - name: Commit & Push
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore: update contributors [skip ci]"
           file_pattern: CONTRIBUTORS.svg


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/pake-cli.yaml`
- Updated `docker/build-push-action` from `v4` to `v6` in `.github/workflows/release.yml`
- Updated `actions/cache` from `v4` to `v5` in `.github/workflows/quality-and-test.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/quality-and-test.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/release.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/pake-cli.yaml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/single-app.yaml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/update-contributors.yml`
- Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/single-app.yaml`
- Updated `stefanzweifel/git-auto-commit-action` from `v5` to `v7` in `.github/workflows/update-contributors.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release.yml`
- Updated `docker/metadata-action` from `v4` to `v5` in `.github/workflows/release.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/single-app.yaml`
