### PR TITLE
refactor: use bash arrays on macOS/Linux to support app names with sp…

### DIFF
--- a/.github/workflows/pake-cli.yaml
+++ b/.github/workflows/pake-cli.yaml
@@ -98,38 +98,38 @@ jobs:
         timeout-minutes: 25
         shell: bash
         run: |
-          ARGS="${{ inputs.url }} --name ${{ inputs.name }}"
+          ARGS=("${{ inputs.url }}" "--name" "${{ inputs.name }}")
 
           if [ -n "${{ inputs.icon }}" ]; then
-            ARGS="$ARGS --icon ${{ inputs.icon }}"
+            ARGS+=("--icon" "${{ inputs.icon }}")
           fi
 
           if [ -n "${{ inputs.width }}" ]; then
-            ARGS="$ARGS --width ${{ inputs.width }}"
+            ARGS+=("--width" "${{ inputs.width }}")
           fi
 
           if [ -n "${{ inputs.height }}" ]; then
-            ARGS="$ARGS --height ${{ inputs.height }}"
+            ARGS+=("--height" "${{ inputs.height }}")
           fi
 
           if [ "${{ inputs.fullscreen }}" == "true" ]; then
-            ARGS="$ARGS --fullscreen"
+            ARGS+=("--fullscreen")
           fi
 
           if [ "${{ inputs.hide_title_bar }}" == "true" ]; then
-            ARGS="$ARGS --hide-title-bar"
+            ARGS+=("--hide-title-bar")
           fi
 
           if [ "${{ inputs.multi_arch }}" == "true" ]; then
-            ARGS="$ARGS --multi-arch"
+            ARGS+=("--multi-arch")
           fi
 
           if [ -n "${{ inputs.targets }}" ] && [ "${{ runner.os }}" == "Linux" ]; then
-            ARGS="$ARGS --targets ${{ inputs.targets }}"
+            ARGS+=("--targets" "${{ inputs.targets }}")
           fi
 
-          echo "Running: node dist/cli.js $ARGS"
-          node dist/cli.js $ARGS
+          echo "Running: node dist/cli.js ${ARGS[@]}"
+          node dist/cli.js "${ARGS[@]}"
 
       - name: Build App (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/single-app.yaml
+++ b/.github/workflows/single-app.yaml
@@ -99,17 +99,17 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         timeout-minutes: 20
         run: |
-          ARGS="${{ inputs.url }} --name ${{ inputs.name }}"
+          ARGS=("${{ inputs.url }}" "--name" "${{ inputs.name }}")
 
           # Auto-detect local icon or use provided icon
           if [ -n "${{ inputs.icon }}" ]; then
-            ARGS="$ARGS --icon ${{ inputs.icon }}"
+            ARGS+=("--icon" "${{ inputs.icon }}")
           elif [ -f "src-tauri/png/${{ inputs.name }}_512.png" ]; then
-            ARGS="$ARGS --icon src-tauri/png/${{ inputs.name }}_512.png"
+            ARGS+=("--icon" "src-tauri/png/${{ inputs.name }}_512.png")
           fi
 
           # Build once with multiple targets (faster than separate builds)
-          node dist/cli.js $ARGS --targets deb,appimage
+          node dist/cli.js "${ARGS[@]}" --targets deb,appimage
 
           mkdir -p output/linux
 
@@ -139,16 +139,16 @@ jobs:
         if: matrix.os == 'macos-latest'
         timeout-minutes: 25
         run: |
-          ARGS="${{ inputs.url }} --name ${{ inputs.name }} --hide-title-bar"
+          ARGS=("${{ inputs.url }}" "--name" "${{ inputs.name }}" "--hide-title-bar")
 
           # Auto-detect local icon or use provided icon
           if [ -n "${{ inputs.icon }}" ]; then
-            ARGS="$ARGS --icon ${{ inputs.icon }}"
+            ARGS+=("--icon" "${{ inputs.icon }}")
           elif [ -f "src-tauri/icons/${{ inputs.name }}.icns" ]; then
-            ARGS="$ARGS --icon src-tauri/icons/${{ inputs.name }}.icns"
+            ARGS+=("--icon" "src-tauri/icons/${{ inputs.name }}.icns")
           fi
 
-          node dist/cli.js $ARGS --targets universal --multi-arch
+          node dist/cli.js "${ARGS[@]}" --targets universal --multi-arch
 
           mkdir -p output/macos
 


### PR DESCRIPTION
## 问题描述

https://github.com/tw93/Pake/issues/541#issuecomment-1827226772

在 Linux 和 macOS 的构建 Workflow 中，CLI 参数是通过字符串拼接构建的。当 App 名称包含空格（例如 `Google Gemini`）时，Bash 会将其错误地拆分为多个参数，导致构建失败：`error: too many arguments. Expected 1 argument but got 2.`

## 解决方案

将参数处理方式从字符串拼接重构为 Bash 数组。这是处理 Shell 参数的最佳实践，能够正确包裹带空格的参数，同时完全兼容现有的不带空格的名称。

> 注：Windows 构建使用的是 PowerShell 数组，原生支持空格，因此无需修改。