### PR TITLE
fix: keep auth links inside app when popup windows are enabled

### DIFF
--- a/src-tauri/src/inject/event.js
+++ b/src-tauri/src/inject/event.js
@@ -503,9 +503,26 @@ document.addEventListener("DOMContentLoaded", () => {
       const absoluteUrl = hrefUrl.href;
       let filename = anchorElement.download || getFilenameFromUrl(absoluteUrl);
 
-      // Early check: Allow OAuth/authentication links to navigate naturally
+      // Keep OAuth/authentication flows inside the app when popup support is enabled.
       if (window.isAuthLink(absoluteUrl)) {
-        console.log("[Pake] Allowing OAuth navigation to:", absoluteUrl);
+        console.log("[Pake] Handling OAuth navigation in-app:", absoluteUrl);
+
+        if (window.pakeConfig?.new_window) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+
+          const authWindow = originalWindowOpen.call(
+            window,
+            absoluteUrl,
+            "_blank",
+            "width=1200,height=800,scrollbars=yes,resizable=yes",
+          );
+
+          if (!authWindow) {
+            window.location.href = absoluteUrl;
+          }
+        }
+
         return;
       }
 


### PR DESCRIPTION
## Summary

- keep detected auth/OAuth links inside the Pake app when popup support is enabled
- prefer in-app popup handling first, then fall back to in-app same-window navigation instead of opening the external browser

## Problem

Apps built with `--new-window` can still send some auth flows (for example Google Drive sign-in via `accounts.google.com`) to the external browser.

This happens because `event.js` detects auth links early, but then lets them "navigate naturally". In practice, some sites route that flow out to the default browser, which breaks the expected in-app sign-in experience.

## Fix

For detected auth links:

- if `window.pakeConfig.new_window` is enabled, intercept the click and try `window.open(..., "_blank", ...)` first
- if popup creation fails, fall back to `window.location.href = absoluteUrl`
- avoid falling back directly to `plugin:shell|open` / external browser for auth links

## Why this is safe

- behavior only changes for URLs already classified as auth links by `auth.js`
- normal external-link handling remains unchanged
- apps without `new_window` continue to behave as before

## Validation

- `pnpm run cli:build`
- built a real Google Drive test app with `PAKE_CREATE_APP=1` + `--new-window --multi-window`
- manually verified the local fix in a rebuilt Google Drive app where sign-in previously escaped to the browser