### PR TITLE
feat: add dashboard-icons as icon fallback source

### DIFF
--- a/bin/options/icon.ts
+++ b/bin/options/icon.ts
@@ -400,12 +400,11 @@ function generateIconServiceUrls(domain: string): string[] {
 
 /**
  * Generates dashboard-icons URLs for an app name.
- * Uses walkxcode/dashboard-icons, the most popular icon set for selfhosted dashboards.
- * Tries multiple slug variations to maximize match rate.
+ * Uses walkxcode/dashboard-icons as a final fallback for selfhosted apps.
+ * Keeps matching conservative to avoid overriding valid site-specific icons.
  */
 function generateDashboardIconUrls(appName: string): string[] {
-  const baseUrl =
-    'https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png';
+  const baseUrl = 'https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png';
   const name = appName.toLowerCase().trim();
   const slugs = new Set<string>();
 
@@ -413,8 +412,6 @@ function generateDashboardIconUrls(appName: string): string[] {
   slugs.add(name);
   // Replace spaces with hyphens
   slugs.add(name.replace(/\s+/g, '-'));
-  // Remove common suffixes
-  slugs.add(name.replace(/[-\s]?(ng|ngx|web|app|server|ui)$/i, ''));
 
   return [...slugs]
     .filter((s) => s.length > 0)
@@ -438,40 +435,6 @@ async function tryGetFavicon(
       ? ICON_CONFIG.downloadTimeout.ci
       : ICON_CONFIG.downloadTimeout.default;
 
-    // Try dashboard-icons first (accurate match by app name, covers
-    // selfhosted apps behind auth where domain-based services fail)
-    if (appName) {
-      const dashboardIconUrls = generateDashboardIconUrls(appName);
-      for (const iconUrl of dashboardIconUrls) {
-        try {
-          const iconPath = await downloadIcon(iconUrl, false, downloadTimeout);
-          if (!iconPath) continue;
-
-          const convertedPath = await convertIconFormat(iconPath, appName);
-          if (convertedPath) {
-            const finalPath = await copyWindowsIconIfNeeded(
-              convertedPath,
-              appName,
-            );
-            spinner.succeed(
-              chalk.green(
-                `Icon found via dashboard-icons for "${appName}"!`,
-              ),
-            );
-            return finalPath;
-          }
-        } catch (error: unknown) {
-          if (error instanceof Error) {
-            logger.debug(
-              `Dashboard icon ${iconUrl} failed: ${error.message}`,
-            );
-          }
-          continue;
-        }
-      }
-    }
-
-    // Fall back to domain-based icon services
     const serviceUrls = generateIconServiceUrls(domain);
 
     for (const serviceUrl of serviceUrls) {
@@ -499,6 +462,37 @@ async function tryGetFavicon(
           logger.debug(`Icon service ${serviceUrl} failed: ${error.message}`);
         }
         continue;
+      }
+    }
+
+    // Final fallback for selfhosted apps behind auth where domain-based
+    // services cannot access the site favicon.
+    if (appName) {
+      const dashboardIconUrls = generateDashboardIconUrls(appName);
+      for (const iconUrl of dashboardIconUrls) {
+        try {
+          const iconPath = await downloadIcon(iconUrl, false, downloadTimeout);
+          if (!iconPath) continue;
+
+          const convertedPath = await convertIconFormat(iconPath, appName);
+          if (convertedPath) {
+            const finalPath = await copyWindowsIconIfNeeded(
+              convertedPath,
+              appName,
+            );
+            spinner.succeed(
+              chalk.green(
+                `Icon found via dashboard-icons fallback for "${appName}"!`,
+              ),
+            );
+            return finalPath;
+          }
+        } catch (error: unknown) {
+          if (error instanceof Error) {
+            logger.debug(`Dashboard icon ${iconUrl} failed: ${error.message}`);
+          }
+          continue;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Adds [walkxcode/dashboard-icons](https://github.com/walkxcode/dashboard-icons) as a primary icon source, matching by `--name` parameter
- When packaging selfhosted apps (Grafana, Proxmox, TrueNAS, etc.) behind authentication, the existing domain-based icon services (logo.dev, Brandfetch, Clearbit, Google Favicons, favicon.ico) fail because they either can't reach the favicon or return an incorrect icon based on the root domain
- Dashboard-icons is tried first by app name; if no match is found, falls back to the existing domain-based services

## Problem

When running e.g. `pake https://grafana.mylab.local --name Grafana`, the icon services try to resolve the favicon for `grafana.mylab.local`. Since the app is behind auth, `/favicon.ico` returns a redirect or error. The services then match the root domain and return an incorrect generic icon.

## Solution

Before trying domain-based services, attempt to fetch the icon from `cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/{name}.png` using the `--name` parameter. This covers 500+ popular selfhosted applications. If the name doesn't match any dashboard icon (404), the existing flow continues unchanged.

## Test plan

- [x] Tested with `--name Grafana` → correct Grafana icon fetched
- [x] Verified Proxmox, TrueNAS slugs resolve (HTTP 200)
- [x] Non-matching names fall through to existing domain-based services
- [ ] Verify no regression for public URLs (e.g. `pake https://twitter.com --name Twitter`)