### PR TITLE
fix: update default user-agent strings to current browser versions

### DIFF
--- a/src-tauri/pake.json
+++ b/src-tauri/pake.json
@@ -24,9 +24,9 @@
     }
   ],
   "user_agent": {
-    "macos": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15",
-    "linux": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
-    "windows": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
+    "macos": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15",
+    "linux": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
+    "windows": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36"
   },
   "system_tray": {
     "macos": false,


### PR DESCRIPTION
## Summary

- Update macOS Safari user-agent from Version/18.2 → Version/26.0
- Update Linux/Windows Chrome user-agent from Chrome/133 → Chrome/147
- Outdated UA strings can cause sites to serve degraded experiences or trigger bot detection

## Changes

Only `src-tauri/pake.json` — the `user_agent` section.

| Platform | Before | After |
|----------|--------|-------|
| macOS | Safari 18.2 | Safari 26.0 |
| Linux | Chrome 133 | Chrome 147 |
| Windows | Chrome 133 | Chrome 147 |