### PR TITLE
fix: handle files without extension in check_file_or_append

### DIFF
--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -1,6 +1,6 @@
 use crate::app::config::PakeConfig;
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Config, Manager, WebviewWindow};
 
 pub fn get_pake_config() -> (PakeConfig, Config) {
@@ -107,9 +107,14 @@ pub fn check_file_or_append(file_path: &str) -> String {
     let mut counter = 0;
 
     while new_path.exists() {
-        let file_stem = new_path.file_stem().unwrap().to_string_lossy().to_string();
-        let extension = new_path.extension().unwrap().to_string_lossy().to_string();
-        let parent_dir = new_path.parent().unwrap();
+        let file_stem = new_path
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let extension = new_path
+            .extension()
+            .map(|e| e.to_string_lossy().to_string());
+        let parent_dir = new_path.parent().unwrap_or(Path::new(""));
 
         let new_file_stem = match file_stem.rfind('-') {
             Some(index) if file_stem[index + 1..].parse::<u32>().is_ok() => {
@@ -123,7 +128,10 @@ pub fn check_file_or_append(file_path: &str) -> String {
             }
         };
 
-        new_path = parent_dir.join(format!("{new_file_stem}.{extension}"));
+        new_path = match &extension {
+            Some(ext) => parent_dir.join(format!("{new_file_stem}.{ext}")),
+            None => parent_dir.join(new_file_stem),
+        };
     }
 
     new_path.to_string_lossy().into_owned()


### PR DESCRIPTION
## Summary

Fixes a panic that occurs when `check_file_or_append` is called with a file path that has no extension (e.g., `Makefile`, `README`, or any downloaded binary without a suffix).

### Root Cause

The original code unconditionally called `.unwrap()` on `PathBuf::extension()`, which returns `None` for extension-less filenames, causing a runtime panic:

```rust
// BEFORE (panics when there is no extension)
let extension = new_path.extension().unwrap().to_string_lossy().to_string();
```

### Fix

Use `.map()` + `unwrap_or_default()` for `file_stem`, and keep `extension` as an `Option<String>`. Then branch on whether the extension is present when constructing the new path:

```rust
// AFTER (handles missing extension gracefully)
let file_stem = new_path
    .file_stem()
    .map(|s| s.to_string_lossy().to_string())
    .unwrap_or_default();
let extension = new_path
    .extension()
    .map(|e| e.to_string_lossy().to_string());
// ...
new_path = match &extension {
    Some(ext) => parent_dir.join(format!("{new_file_stem}.{ext}")),
    None => parent_dir.join(new_file_stem),
};
```

This also adds `use std::path::Path;` to support the `Path::new("")` fallback for the edge case where `parent()` returns `None`.

Closes #1183