### PR TITLE
fix: macOS - surface native Move & Resize options

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -3066,7 +3066,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src-tauri/src/app/menu.rs
+++ b/src-tauri/src/app/menu.rs
@@ -6,9 +6,11 @@ use tauri::menu::{AboutMetadata, Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::{AppHandle, Manager, Wry};
 use tauri_plugin_opener::OpenerExt;
 
-pub fn get_menu(app: &AppHandle<Wry>, allow_multi_window: bool) -> tauri::Result<Menu<Wry>> {
+pub fn set_app_menu(app: &AppHandle<Wry>, allow_multi_window: bool) -> tauri::Result<()> {
     let pake_version = env!("CARGO_PKG_VERSION");
     let pake_menu_item_title = format!("Built with Pake V{}", pake_version);
+
+    let window_submenu = window_menu(app)?;
 
     let menu = Menu::with_items(
         app,
@@ -18,12 +20,18 @@ pub fn get_menu(app: &AppHandle<Wry>, allow_multi_window: bool) -> tauri::Result
             &edit_menu(app)?,
             &view_menu(app)?,
             &navigation_menu(app)?,
-            &window_menu(app)?,
+            &window_submenu,
             &help_menu(app, &pake_menu_item_title)?,
         ],
     )?;
 
-    Ok(menu)
+    app.set_menu(menu)?;
+
+    // AppKit injects Move & Resize, Fill, Center, Full Screen Tile, and
+    // window-cycling once the submenu is registered as the windows menu.
+    window_submenu.set_as_windows_menu_for_nsapp()?;
+
+    Ok(())
 }
 
 fn app_menu(app: &AppHandle<Wry>) -> tauri::Result<Submenu<Wry>> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,8 +93,7 @@ pub fn run_app() {
             // --- Menu Construction Start ---
             #[cfg(target_os = "macos")]
             {
-                let menu = app::menu::get_menu(app.app_handle(), multi_window)?;
-                app.set_menu(menu)?;
+                app::menu::set_app_menu(app.app_handle(), multi_window)?;
 
                 // Event Handling for Custom Menu Item
                 app.on_menu_event(move |app_handle, event| {


### PR DESCRIPTION
macOS has native window size and position options, but these were only found in Pake via the traffic lights i.e.
<img width="624" height="528" alt="Screenshot 2026-05-07 at 15 41 37" src="https://github.com/user-attachments/assets/add1e409-c885-442d-9173-634f4c0d8dea" />

The same options _should_ be surfaced in the Window menu e.g.
<img width="1184" height="1208" alt="Screenshot 2026-05-07 at 15 57 08" src="https://github.com/user-attachments/assets/73fce791-e1b2-489f-b3c8-e34078daaccf" />

This PR corrects that, which also enables the system-wide shortcuts e.g.  ⌃🌐◀︎