### PR TITLE
fix: save downloads natively so they work under strict CSP (e.g. Gemini)

### DIFF
--- a/src-tauri/src/app/window.rs
+++ b/src-tauri/src/app/window.rs
@@ -1,12 +1,14 @@
 use crate::app::config::PakeConfig;
-use crate::util::get_data_dir;
+use crate::util::{
+    check_file_or_append, get_data_dir, get_download_message_with_lang, show_toast, MessageType,
+};
 use std::{
     path::PathBuf,
     str::FromStr,
     sync::atomic::{AtomicU32, Ordering},
 };
 use tauri::{
-    webview::{NewWindowFeatures, NewWindowResponse},
+    webview::{DownloadEvent, NewWindowFeatures, NewWindowResponse},
     AppHandle, Config, Manager, Url, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
 };
 
@@ -424,6 +426,61 @@ fn build_window(
         {
             window_builder = window_builder.window_features(features).focused(true);
         }
+    }
+
+    // Capture webview-initiated downloads (blob:, data:, Content-Disposition,
+    // etc.) and write them to the OS Downloads folder. This is essential for
+    // sites with a strict Content-Security-Policy (e.g. Gemini): their
+    // `connect-src` blocks Tauri's IPC origin, so downloads cannot be routed
+    // through the JS bridge, and downloads triggered from a sandboxed iframe
+    // can't reach the IPC either. Letting the browser download natively and
+    // catching it here is independent of the page CSP and the IPC channel.
+    {
+        let download_handle = app.clone();
+        window_builder = window_builder.on_download(move |_webview, event| match event {
+            DownloadEvent::Requested { url, destination } => {
+                match download_handle.path().download_dir() {
+                    Ok(download_dir) => {
+                        let filename = destination
+                            .file_name()
+                            .map(|name| name.to_string_lossy().to_string())
+                            .filter(|name| !name.is_empty())
+                            .or_else(|| {
+                                url.path_segments()
+                                    .and_then(|segments| segments.last())
+                                    .map(|segment| segment.to_string())
+                                    .filter(|segment| !segment.is_empty())
+                            })
+                            .unwrap_or_else(|| "download".to_string());
+
+                        let target = download_dir.join(filename);
+                        if let Some(path_str) = target.to_str() {
+                            *destination = PathBuf::from(check_file_or_append(path_str));
+                        }
+                    }
+                    Err(error) => {
+                        eprintln!("[Pake] Failed to resolve download dir: {error}");
+                    }
+                }
+                true
+            }
+            DownloadEvent::Finished {
+                url: _,
+                path: _,
+                success,
+            } => {
+                if success {
+                    if let Some(window) = download_handle.get_webview_window("pake") {
+                        show_toast(
+                            &window,
+                            &get_download_message_with_lang(MessageType::Success, None),
+                        );
+                    }
+                }
+                true
+            }
+            _ => true,
+        });
     }
 
     window_builder = window_builder.on_navigation(|_| true);

--- a/src-tauri/src/inject/event.js
+++ b/src-tauri/src/inject/event.js
@@ -423,37 +423,6 @@ document.addEventListener("DOMContentLoaded", () => {
       });
   }
 
-  // detect blob download by createElement("a")
-  function detectDownloadByCreateAnchor() {
-    const createEle = document.createElement;
-    document.createElement = (el) => {
-      if (el !== "a") return createEle.call(document, el);
-      const anchorEle = createEle.call(document, el);
-
-      // use addEventListener to avoid overriding the original click event.
-      anchorEle.addEventListener(
-        "click",
-        (e) => {
-          const url = anchorEle.href;
-          const filename = anchorEle.download || getFilenameFromUrl(url);
-          if (window.blobToUrlCaches.has(url)) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-            downloadFromBlobUrl(url, filename);
-            // case: download from dataURL -> convert dataURL ->
-          } else if (url.startsWith("data:")) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-            downloadFromDataUri(url, filename);
-          }
-        },
-        true,
-      );
-
-      return anchorEle;
-    };
-  }
-
   // process special download protocol['data:','blob:']
   const isSpecialDownload = (url) =>
     ["blob", "data"].some((protocol) => url.startsWith(protocol));
@@ -587,11 +556,16 @@ document.addEventListener("DOMContentLoaded", () => {
         return;
       }
 
-      // Process download links for Rust to handle.
-      if (
-        isDownloadRequired(absoluteUrl, anchorElement, e) &&
-        !isSpecialDownload(absoluteUrl)
-      ) {
+      // Process download links.
+      if (isDownloadRequired(absoluteUrl, anchorElement, e)) {
+        // Let the browser download blob:/data: URLs natively; the Rust
+        // on_download handler saves them to the Downloads folder. Routing them
+        // through the IPC fails on strict-CSP sites (e.g. Gemini), whose
+        // connect-src blocks the IPC origin, and on downloads triggered from a
+        // sandboxed iframe where the IPC can't be reached.
+        if (isSpecialDownload(absoluteUrl)) {
+          return;
+        }
         e.preventDefault();
         e.stopImmediatePropagation();
         const userLanguage = getUserLanguage();
@@ -626,7 +600,6 @@ document.addEventListener("DOMContentLoaded", () => {
   document.addEventListener("click", detectAnchorElementClick, true);
 
   collectUrlToBlobs();
-  detectDownloadByCreateAnchor();
 
   // Rewrite the window.open function.
   const originalWindowOpen = window.open;


### PR DESCRIPTION
Image/file downloads silently failed in apps wrapping strict-CSP sites such as Gemini: the file never appeared in Downloads even though the site showed its own "downloaded" confirmation.

Root cause: Pake intercepted blob:/data: download-anchor clicks and pushed the bytes to Rust through the Tauri IPC (download_file_by_binary). That IPC call is an HTTP request to Tauri's IPC origin (http://ipc.localhost), which the page's Content-Security-Policy `connect-src` blocks on sites like Gemini. The download is also frequently triggered from inside a sandboxed `srcdoc` iframe, where Tauri's postMessage IPC fallback can't route either. So the bytes never reached Rust and nothing was written, while the site's own UI still reported success.

Fix: let the browser perform blob:/data: downloads natively and capture them in a WebViewWindowBuilder::on_download handler that writes the file to the OS Downloads folder. The native download path is independent of the page CSP and the IPC channel, so it works on both permissive and strict-CSP sites. In a normal browser these downloads already work from that iframe (it grants `allow-downloads`); Pake was the only thing breaking them.

- window.rs: add on_download handler (resolves filename, writes to the Downloads dir, de-dupes via check_file_or_append, toasts on success).
- event.js: remove detectDownloadByCreateAnchor (the createElement('a') click interceptor that hijacked blob/data clicks into the IPC) and let blob:/data: downloads fall through to the native path in the click handler.

Fixes #1157