### PR TITLE
Fix unused variable warning for enable_find on non-macOS platforms

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,7 +43,7 @@ pub fn run_app() {
     let start_to_tray = pake_config.windows[0].start_to_tray && show_system_tray; // Only valid when tray is enabled
     let multi_instance = pake_config.multi_instance;
     let multi_window = pake_config.multi_window;
-    let enable_find = pake_config.windows[0].enable_find;
+    let _enable_find = pake_config.windows[0].enable_find;
 
     let window_state_plugin = WindowStatePlugin::default()
         .with_state_flags(if init_fullscreen {
@@ -99,7 +99,7 @@ pub fn run_app() {
             // --- Menu Construction Start ---
             #[cfg(target_os = "macos")]
             {
-                app::menu::set_app_menu(app.app_handle(), multi_window, enable_find)?;
+                app::menu::set_app_menu(app.app_handle(), multi_window, _enable_find)?;
 
                 // Event Handling for Custom Menu Item
                 app.on_menu_event(move |app_handle, event| {


### PR DESCRIPTION
Prefixes `enable_find` with an underscore to suppress the `unused_variables` compiler warning that occurs on Windows and Linux builds.
The `enable_find` variable is only consumed inside a `#[cfg(target_os = "macos")] `block (line 102), making it appear unused on other platforms. This is the standard Rust convention for platform-conditional variables.

**Changes**:
- src-tauri/src/lib.rs:46 — `let enable_find` → `let _enable_find`
- src-tauri/src/lib.rs:102 — `enable_find` → `_enable_find`

**Before**: 1 compiler warning (`unused variable: enable_find`)
**After**: 0 warnings