### PR TITLE
feat: add --hide-window-buttons option for macOS

### DIFF
--- a/bin/defaults.ts
+++ b/bin/defaults.ts
@@ -54,6 +54,7 @@ export const DEFAULT_PAKE_OPTIONS: PakeCliOptions = {
   install: false,
   camera: false,
   microphone: false,
+  hideWindowButtons: false,
 };
 
 // Just for cli development

--- a/bin/helpers/cli-program.ts
+++ b/bin/helpers/cli-program.ts
@@ -45,6 +45,7 @@ ${green('|_|   \\__,_|_|\\_\\___|  can turn any webpage into a desktop app with 
     )
     .option('--fullscreen', 'Start in full screen', DEFAULT.fullscreen)
     .option('--hide-title-bar', 'For Mac, hide title bar', DEFAULT.hideTitleBar)
+    .option('--hide-window-buttons', 'For Mac, hide traffic light buttons (close/minimize/maximize)', DEFAULT.hideWindowButtons)
     .option('--multi-arch', 'For Mac, both Intel and M1', DEFAULT.multiArch)
     .option(
       '--inject <files>',

--- a/bin/helpers/merge.ts
+++ b/bin/helpers/merge.ts
@@ -55,6 +55,7 @@ export function buildWindowConfigOverrides(
     min_height: options.minHeight,
     ignore_certificate_errors: options.ignoreCertificateErrors,
     new_window: options.newWindow,
+    hide_window_buttons: options.hideWindowButtons,
   };
 }
 

--- a/bin/types.ts
+++ b/bin/types.ts
@@ -137,6 +137,9 @@ export interface PakeCliOptions {
 
   // Request microphone entitlement on macOS, default false
   microphone: boolean;
+
+  // For Mac, hide window traffic light buttons (close/minimize/maximize), default false
+  hideWindowButtons: boolean;
 }
 
 export interface PakeAppOptions extends PakeCliOptions {
@@ -176,6 +179,7 @@ export interface WindowConfig {
   min_height: number;
   ignore_certificate_errors: boolean;
   new_window: boolean;
+  hide_window_buttons: boolean;
 }
 
 export interface PakeConfig {

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -471,6 +471,7 @@ function buildWindowConfigOverrides(options, platform = asSupportedPlatform(proc
         min_height: options.minHeight,
         ignore_certificate_errors: options.ignoreCertificateErrors,
         new_window: options.newWindow,
+        hide_window_buttons: options.hideWindowButtons,
     };
 }
 function asSupportedPlatform(platform) {
@@ -2446,6 +2447,7 @@ const DEFAULT_PAKE_OPTIONS = {
     install: false,
     camera: false,
     microphone: false,
+    hideWindowButtons: false,
 };
 
 function validateNumberInput(value) {
@@ -2492,6 +2494,7 @@ ${green('|_|   \\__,_|_|\\_\\___|  can turn any webpage into a desktop app with 
         .option('--use-local-file', 'Use local file packaging', DEFAULT_PAKE_OPTIONS.useLocalFile)
         .option('--fullscreen', 'Start in full screen', DEFAULT_PAKE_OPTIONS.fullscreen)
         .option('--hide-title-bar', 'For Mac, hide title bar', DEFAULT_PAKE_OPTIONS.hideTitleBar)
+        .option('--hide-window-buttons', 'For Mac, hide traffic light buttons (close/minimize/maximize)', DEFAULT_PAKE_OPTIONS.hideWindowButtons)
         .option('--multi-arch', 'For Mac, both Intel and M1', DEFAULT_PAKE_OPTIONS.multiArch)
         .option('--inject <files>', 'Inject local CSS/JS files into the page', (val, previous) => {
         if (!val)

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,7 +38,7 @@ tauri-plugin-notification = "2.3.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSDockTile"] }
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSDockTile", "NSWindow", "NSButton"] }
 objc2-foundation = { version = "0.3", features = ["NSString"] }
 
 [features]

--- a/src-tauri/src/app/config.rs
+++ b/src-tauri/src/app/config.rs
@@ -36,6 +36,8 @@ pub struct WindowConfig {
     pub min_height: f64,
     #[serde(default)]
     pub ignore_certificate_errors: bool,
+    #[serde(default)]
+    pub hide_window_buttons: bool,
 }
 
 fn default_zoom() -> u32 {

--- a/src-tauri/src/app/window.rs
+++ b/src-tauri/src/app/window.rs
@@ -347,12 +347,15 @@ fn build_window(
     // Platform-specific configuration must be set before proxy on Windows/Linux
     #[cfg(target_os = "macos")]
     {
-        let title_bar_style = if window_config.hide_title_bar {
-            TitleBarStyle::Overlay
-        } else {
-            TitleBarStyle::Visible
-        };
-        window_builder = window_builder.title_bar_style(title_bar_style);
+        // When both flags are set, use a fully frameless window so the title bar
+        // area is removed entirely (no safe-area inset pushed down by macOS).
+        // When only hide_title_bar is set, use Overlay (transparent title bar with
+        // traffic lights still rendered over the content).
+        if window_config.hide_title_bar && window_config.hide_window_buttons {
+            window_builder = window_builder.decorations(false);
+        } else if window_config.hide_title_bar {
+            window_builder = window_builder.title_bar_style(TitleBarStyle::Overlay);
+        }
 
         // Default to following system theme (None), only force dark when explicitly set
         let theme = if window_config.dark_mode {
@@ -493,13 +496,19 @@ fn build_window(
 
         if let Ok(ns_win_ptr) = window.ns_window() {
             let ns_win = unsafe { &*(ns_win_ptr as *const NSWindow) };
-            for button_type in [
-                NSWindowButton::CloseButton,
-                NSWindowButton::MiniaturizeButton,
-                NSWindowButton::ZoomButton,
-            ] {
-                if let Some(button) = ns_win.standardWindowButton(button_type) {
-                    button.setHidden(true);
+            if window_config.hide_title_bar {
+                // decorations(false) already removed the buttons; restore the drop shadow
+                // that borderless windows lose by default.
+                ns_win.setHasShadow(true);
+            } else {
+                for button_type in [
+                    NSWindowButton::CloseButton,
+                    NSWindowButton::MiniaturizeButton,
+                    NSWindowButton::ZoomButton,
+                ] {
+                    if let Some(button) = ns_win.standardWindowButton(button_type) {
+                        button.setHidden(true);
+                    }
                 }
             }
         }

--- a/src-tauri/src/app/window.rs
+++ b/src-tauri/src/app/window.rs
@@ -485,7 +485,27 @@ fn build_window(
 
     window_builder = window_builder.on_navigation(|_| true);
 
-    window_builder.build()
+    let window = window_builder.build()?;
+
+    #[cfg(target_os = "macos")]
+    if window_config.hide_window_buttons {
+        use objc2_app_kit::{NSWindow, NSWindowButton};
+
+        if let Ok(ns_win_ptr) = window.ns_window() {
+            let ns_win = unsafe { &*(ns_win_ptr as *const NSWindow) };
+            for button_type in [
+                NSWindowButton::CloseButton,
+                NSWindowButton::MiniaturizeButton,
+                NSWindowButton::ZoomButton,
+            ] {
+                if let Some(button) = ns_win.standardWindowButton(button_type) {
+                    button.setHidden(true);
+                }
+            }
+        }
+    }
+
+    Ok(window)
 }
 
 #[cfg(all(test, target_os = "windows"))]

--- a/src-tauri/src/app/window.rs
+++ b/src-tauri/src/app/window.rs
@@ -347,15 +347,12 @@ fn build_window(
     // Platform-specific configuration must be set before proxy on Windows/Linux
     #[cfg(target_os = "macos")]
     {
-        // When both flags are set, use a fully frameless window so the title bar
-        // area is removed entirely (no safe-area inset pushed down by macOS).
-        // When only hide_title_bar is set, use Overlay (transparent title bar with
-        // traffic lights still rendered over the content).
-        if window_config.hide_title_bar && window_config.hide_window_buttons {
-            window_builder = window_builder.decorations(false);
-        } else if window_config.hide_title_bar {
-            window_builder = window_builder.title_bar_style(TitleBarStyle::Overlay);
-        }
+        let title_bar_style = if window_config.hide_title_bar {
+            TitleBarStyle::Overlay
+        } else {
+            TitleBarStyle::Visible
+        };
+        window_builder = window_builder.title_bar_style(title_bar_style);
 
         // Default to following system theme (None), only force dark when explicitly set
         let theme = if window_config.dark_mode {
@@ -492,14 +489,18 @@ fn build_window(
 
     #[cfg(target_os = "macos")]
     if window_config.hide_window_buttons {
-        use objc2_app_kit::{NSWindow, NSWindowButton};
+        use objc2_app_kit::{NSWindow, NSWindowButton, NSWindowStyleMask};
 
         if let Ok(ns_win_ptr) = window.ns_window() {
             let ns_win = unsafe { &*(ns_win_ptr as *const NSWindow) };
             if window_config.hide_title_bar {
-                // decorations(false) already removed the buttons; restore the drop shadow
-                // that borderless windows lose by default.
-                ns_win.setHasShadow(true);
+                // Remove the Titled bit from the style mask. This surgically strips the
+                // title bar area (and its traffic-light buttons) from the window without
+                // going fully borderless, so shadow and resizability are preserved.
+                // It also eliminates the safe-area inset macOS would otherwise inject
+                // into WKWebView when a title bar is present.
+                let mask = ns_win.styleMask();
+                ns_win.setStyleMask(mask & !NSWindowStyleMask::Titled);
             } else {
                 for button_type in [
                     NSWindowButton::CloseButton,


### PR DESCRIPTION
## Summary

Adds a new `--hide-window-buttons` CLI flag (and corresponding `hide_window_buttons` window config field) that hides the macOS traffic-light buttons (close / minimize / maximize) while keeping the title bar area.

Also fixes the dead-space padding that appears when both `--hide-title-bar` and `--hide-window-buttons` are used together.

## Changes

### New option
- `--hide-window-buttons` flag in CLI (`bin/helpers/cli-program.ts`)
- `hideWindowButtons` field in TypeScript interfaces (`bin/types.ts`) and defaults (`bin/defaults.ts`)
- `hide_window_buttons: bool` in `WindowConfig` (`src-tauri/src/app/config.rs`)
- CLI→config mapping in `bin/helpers/merge.ts`
- macOS post-build: calls `standardWindowButton().setHidden(true)` for Close / Miniaturize / Zoom

### Padding fix (both flags combined)
When `--hide-title-bar` **and** `--hide-window-buttons` are both active, the builder still uses `TitleBarStyle::Overlay`. After the window is created, the `.Titled` bit is removed from `NSWindow.styleMask`. This:
- Strips the title bar chrome and buttons in one shot
- Eliminates the macOS safe-area inset that WKWebView inherits from the title bar (the dead space at the top)
- Preserves window shadow, resizability, and all other standard window behaviour

## Usage

```sh
# Hide only the traffic-light buttons (title bar remains, buttons invisible)
pake https://example.com --hide-window-buttons

# Hide both title bar and buttons with no top padding
pake https://example.com --hide-title-bar --hide-window-buttons
```