### PR TITLE
docs: add missing cli:dev script alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "analyze": "cd src-tauri && cargo bloat --release --crates",
     "tauri": "tauri",
     "cli": "cross-env NODE_ENV=development rollup -c -w",
+    "cli:dev": "cross-env NODE_ENV=development rollup -c -w",
     "cli:build": "cross-env NODE_ENV=production rollup -c",
     "test": "pnpm run cli:build && cross-env PAKE_CREATE_APP=1 node tests/index.js",
     "format": "prettier --write . --ignore-unknown && find tests -name '*.js' -exec sed -i '' 's/[[:space:]]*$//' {} \\; && cd src-tauri && cargo fmt --verbose",


### PR DESCRIPTION
## What
Adds a `cli:dev` npm script alias that runs the same development Rollup watch command as the existing `cli` script.

## Why
The contributor docs and agent guidance reference `pnpm run cli:dev`, but `package.json` currently does not define that script. This can make the documented CLI development flow fail before contributors reach the Tauri dev step.

## Before / After
Before: `pnpm run cli:dev` failed with a missing script error.
After: `pnpm run cli:dev` runs the existing development Rollup watch command.

## Verification
- `node -e "const p=require('./package.json'); if(p.scripts['cli:dev']!==p.scripts.cli) process.exit(1); console.log(p.scripts['cli:dev'])"`
- `git diff --check`