### PR TITLE
fix: reject malformed zoom values

### DIFF
--- a/bin/helpers/cli-program.ts
+++ b/bin/helpers/cli-program.ts
@@ -212,8 +212,8 @@ ${green('|_|   \\__,_|_|\\_\\___|  can turn any webpage into a desktop app with 
       new Option('--zoom <number>', 'Initial page zoom level (50-200)')
         .default(DEFAULT.zoom)
         .argParser((value) => {
-          const zoom = parseInt(value);
-          if (isNaN(zoom) || zoom < 50 || zoom > 200) {
+          const zoom = Number(value);
+          if (!Number.isFinite(zoom) || zoom < 50 || zoom > 200) {
             throw new Error('--zoom must be a number between 50 and 200');
           }
           return zoom;

--- a/tests/unit/cli-options.test.ts
+++ b/tests/unit/cli-options.test.ts
@@ -46,4 +46,14 @@ describe('CLI options', () => {
     expect(option?.defaultValue).toBe(false);
     expect(option?.hidden).toBe(true);
   });
+
+  it('rejects malformed zoom values instead of truncating them', () => {
+    const option = program.options.find((item) => item.long === '--zoom');
+
+    expect(option).toBeDefined();
+    expect(option?.parseArg?.('80', undefined)).toBe(80);
+    expect(() => option?.parseArg?.('80abc', undefined)).toThrow(
+      '--zoom must be a number between 50 and 200',
+    );
+  });
 });


### PR DESCRIPTION
## What
Uses `Number(value)` for `--zoom` parsing and adds a focused unit test for malformed values.

## Why
`parseInt` accepts partially numeric strings, so `--zoom 80abc` was parsed as `80` instead of being rejected. The option help says zoom must be a number between 50 and 200, so malformed numeric input should fail clearly.

## Before / After
Before: `--zoom 80abc` was accepted and silently treated as `80`.
After: `--zoom 80abc` throws `--zoom must be a number between 50 and 200`.

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec vitest run tests/unit/cli-options.test.ts`
- `git diff --check`