### PR TITLE
fix: reject non-finite CLI numbers

### DIFF
--- a/bin/utils/validate.ts
+++ b/bin/utils/validate.ts
@@ -4,7 +4,7 @@ import { normalizeUrl } from './url';
 
 export function validateNumberInput(value: string) {
   const parsedValue = Number(value);
-  if (isNaN(parsedValue)) {
+  if (!Number.isFinite(parsedValue)) {
     throw new InvalidArgumentError('Not a number.');
   }
   return parsedValue;

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -2430,7 +2430,7 @@ const DEFAULT_PAKE_OPTIONS = {
 
 function validateNumberInput(value) {
     const parsedValue = Number(value);
-    if (isNaN(parsedValue)) {
+    if (!Number.isFinite(parsedValue)) {
         throw new InvalidArgumentError('Not a number.');
     }
     return parsedValue;

--- a/tests/unit/cli-options.test.ts
+++ b/tests/unit/cli-options.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { getCliProgram } from '../../bin/helpers/cli-program.js';
+import { validateNumberInput } from '../../bin/utils/validate.js';
 
 describe('CLI options', () => {
   const program = getCliProgram();
@@ -45,5 +46,11 @@ describe('CLI options', () => {
     expect(option).toBeDefined();
     expect(option?.defaultValue).toBe(false);
     expect(option?.hidden).toBe(true);
+  });
+
+  it('rejects non-finite numeric option values', () => {
+    expect(() => validateNumberInput('Infinity')).toThrow('Not a number.');
+    expect(() => validateNumberInput('-Infinity')).toThrow('Not a number.');
+    expect(validateNumberInput('1200')).toBe(1200);
   });
 });


### PR DESCRIPTION
## What changed

This updates the shared CLI numeric validator to reject non-finite values such as `Infinity` and `-Infinity`.

## Problem

`validateNumberInput()` currently checks `isNaN(Number(value))`. That rejects values like `abc`, but `Number("Infinity")` is not `NaN`, so options using the shared parser, such as `--width`, `--height`, `--min-width`, and `--min-height`, can accept non-finite numbers.

## Before / after

Before:
- `--width Infinity` could pass the shared numeric parser.

After:
- Non-finite numeric values are rejected with the existing `Not a number.` error.
- Normal finite numeric values still parse as before.

## Verification

Ran locally:

```text
corepack pnpm exec vitest run tests/unit/cli-options.test.ts
corepack pnpm run cli:build
git diff --check
```