### PR TITLE
fix: reject blank numeric CLI values

### DIFF
--- a/bin/utils/validate.ts
+++ b/bin/utils/validate.ts
@@ -3,6 +3,9 @@ import { InvalidArgumentError } from 'commander';
 import { normalizeUrl } from './url';
 
 export function validateNumberInput(value: string) {
+  if (value.trim() === '') {
+    throw new InvalidArgumentError('Not a number.');
+  }
   const parsedValue = Number(value);
   if (!Number.isFinite(parsedValue)) {
     throw new InvalidArgumentError('Not a number.');

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -2540,6 +2540,9 @@ const DEFAULT_PAKE_OPTIONS = {
 };
 
 function validateNumberInput(value) {
+    if (value.trim() === '') {
+        throw new InvalidArgumentError('Not a number.');
+    }
     const parsedValue = Number(value);
     if (!Number.isFinite(parsedValue)) {
         throw new InvalidArgumentError('Not a number.');

--- a/tests/unit/cli-options.test.ts
+++ b/tests/unit/cli-options.test.ts
@@ -64,6 +64,11 @@ describe('CLI options', () => {
     expect(validateNumberInput('1200')).toBe(1200);
   });
 
+  it('rejects blank numeric option values', () => {
+    expect(() => validateNumberInput('')).toThrow('Not a number.');
+    expect(() => validateNumberInput('   ')).toThrow('Not a number.');
+  });
+
   it('rejects negative numeric option values', () => {
     expect(() => validateNumberInput('-100')).toThrow('Must not be negative.');
     expect(validateNumberInput('0')).toBe(0);


### PR DESCRIPTION
## What changed
- Reject empty or whitespace-only values in the shared numeric CLI validator.
- Added a regression test for blank numeric values.
- Rebuilt `dist/cli.js` so the published CLI bundle matches the source change.

## Problem
`validateNumberInput()` used `Number(value)` directly. In JavaScript, `Number("")` and `Number("   ")` both evaluate to `0`, so blank input could be accepted as a valid numeric value for options using this shared validator, such as `--min-width` and `--min-height`.

## Before / after
Before:
- `validateNumberInput("")` returned `0`.
- `validateNumberInput("   ")` returned `0`.

After:
- Blank or whitespace-only numeric values throw `InvalidArgumentError("Not a number.")`.
- Existing valid values like `1200` and `0` keep working.

## Verification
- `corepack pnpm exec vitest run tests/unit/cli-options.test.ts` → 9 tests passed.
- `corepack pnpm run cli:build` completed successfully and regenerated `dist/cli.js`.
- `git diff --check` passes.
