### PR TITLE
fix: scope SSO auth detection to host and endpoint paths, document --safe-domain

### DIFF
--- a/.agents/skills/use-pake/SKILL.md
+++ b/.agents/skills/use-pake/SKILL.md
@@ -111,6 +111,7 @@ After build, confirm:
 | `--multi-instance`            | false   | Allow multiple app instances                 |
 | `--multi-window`              | false   | Multiple windows in one instance             |
 | `--new-window`                | false   | Allow popup windows (needed for OAuth flows) |
+| `--safe-domain <domains>`     | none    | Keep trusted SSO/workspace domains in-app    |
 | `--incognito`                 | false   | Private browsing mode                        |
 | `--dark-mode`                 | false   | Force macOS dark mode                        |
 | `--zoom <number>`             | 100     | Initial zoom level (50-200)                  |

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -262,6 +262,17 @@ Set a regex pattern to determine which URLs should be considered internal (opene
 --internal-url-regex "^https://(app|api)\\.example\\.com"
 ```
 
+#### [safe-domain]
+
+Comma-separated list of domains to keep inside the app — convenience sugar over `--internal-url-regex`. Each domain (and its subdomains) is matched only in the URL's host position, so SSO and workspace callbacks stay in the app instead of opening in the system browser, while look-alike URLs such as `https://slack.com.evil.test` are not treated as internal. When `--internal-url-regex` is also set, the explicit regex takes precedence.
+
+```shell
+--safe-domain <domains>
+
+# Example: keep Slack and its SSO provider inside the app
+--safe-domain slack.com,okta.com
+```
+
 #### [multi-arch]
 
 Package the application to support both Intel and M1 chips, exclusively for macOS. Default is `false`.

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -264,12 +264,14 @@ Set a regex pattern to determine which URLs should be considered internal (opene
 
 #### [safe-domain]
 
-Comma-separated list of domains to keep inside the app — convenience sugar over `--internal-url-regex`. Each domain (and its subdomains) is matched only in the URL's host position, so SSO and workspace callbacks stay in the app instead of opening in the system browser, while look-alike URLs such as `https://slack.com.evil.test` are not treated as internal. When `--internal-url-regex` is also set, the explicit regex takes precedence.
+A simpler way to keep trusted domains and their subdomains inside the app. This is useful for workspace callbacks and enterprise SSO flows, for example Slack plus Okta. Pake compiles this list into `internal_url_regex`; if `--internal-url-regex` is also set, the explicit regex wins.
+
+`--safe-domain` matches URL hosts only, not arbitrary path or query text.
 
 ```shell
 --safe-domain <domains>
 
-# Example: keep Slack and its SSO provider inside the app
+# Keep Slack and Okta auth redirects inside the app
 --safe-domain slack.com,okta.com
 ```
 

--- a/docs/cli-usage_CN.md
+++ b/docs/cli-usage_CN.md
@@ -260,6 +260,17 @@ pake https://github.com --name GitHub
 --internal-url-regex "^https://(app|api)\\.example\\.com"
 ```
 
+#### [safe-domain]
+
+以逗号分隔的域名列表，用于让这些域名始终在应用内打开——它是 `--internal-url-regex` 的便捷写法。每个域名（及其子域名）只在 URL 的主机位置匹配，因此 SSO 和工作区回调会留在应用内，而不会切换到系统浏览器；同时像 `https://slack.com.evil.test` 这类仿冒地址不会被视为内部链接。若同时设置了 `--internal-url-regex`，则以显式正则为准。
+
+```shell
+--safe-domain <domains>
+
+# 示例：让 Slack 及其 SSO 提供商在应用内打开
+--safe-domain slack.com,okta.com
+```
+
 #### [multi-arch]
 
 设置打包结果同时支持 Intel 和 M1 芯片，仅适用于 macOS，默认为 `false`。

--- a/docs/cli-usage_CN.md
+++ b/docs/cli-usage_CN.md
@@ -262,12 +262,14 @@ pake https://github.com --name GitHub
 
 #### [safe-domain]
 
-以逗号分隔的域名列表，用于让这些域名始终在应用内打开——它是 `--internal-url-regex` 的便捷写法。每个域名（及其子域名）只在 URL 的主机位置匹配，因此 SSO 和工作区回调会留在应用内，而不会切换到系统浏览器；同时像 `https://slack.com.evil.test` 这类仿冒地址不会被视为内部链接。若同时设置了 `--internal-url-regex`，则以显式正则为准。
+更简单地把可信域名及其子域名保留在应用内打开。适合工作区回调和企业 SSO 登录流程，例如 Slack 加 Okta。Pake 会把这个列表编译成 `internal_url_regex`；如果同时设置了 `--internal-url-regex`，则以显式正则为准。
+
+`--safe-domain` 只匹配 URL 的 host，不会因为路径或查询参数里出现域名就误判为内部链接。
 
 ```shell
 --safe-domain <domains>
 
-# 示例：让 Slack 及其 SSO 提供商在应用内打开
+# 将 Slack 和 Okta 的认证跳转保留在应用内
 --safe-domain slack.com,okta.com
 ```
 

--- a/src-tauri/src/inject/auth.js
+++ b/src-tauri/src/inject/auth.js
@@ -17,12 +17,6 @@ function matchesAuthUrl(url, baseUrl = window.location.href) {
       /facebook\.com\/.*\/dialog/,
       /twitter\.com\/oauth/,
       /appleid\.apple\.com/,
-      // Enterprise SSO providers and SAML/ADFS endpoints
-      /\.okta\.com/,
-      /\.onelogin\.com/,
-      /\/saml\//,
-      /\/sso\//,
-      /adfs\/ls/,
       /\/oauth\//,
       /\/auth\//,
       /\/authorize/,
@@ -33,12 +27,26 @@ function matchesAuthUrl(url, baseUrl = window.location.href) {
       /\/o\/oauth2/,
     ];
 
-    const isMatch = oauthPatterns.some(
-      (pattern) =>
-        pattern.test(hostname) ||
-        pattern.test(pathname) ||
-        pattern.test(fullUrl),
-    );
+    // Enterprise SSO. Match identity providers on the host, and SAML/SSO/ADFS on
+    // the pathname with endpoint-shaped patterns only, so ordinary pages such as
+    // /settings/sso/providers (or a query string carrying an SSO URL) are not
+    // misread as authentication.
+    const enterpriseHostPatterns = [/(^|\.)okta\.com$/, /(^|\.)onelogin\.com$/];
+    const enterprisePathPatterns = [
+      /\/saml2?\/(sso|acs|login|metadata|consume|redirect|callback|continue)/,
+      /\/sso\/(saml|oidc|oauth|login|authorize|redirect|callback|acs|start|continue|metadata)/,
+      /\/adfs\/ls\b/,
+    ];
+
+    const isMatch =
+      oauthPatterns.some(
+        (pattern) =>
+          pattern.test(hostname) ||
+          pattern.test(pathname) ||
+          pattern.test(fullUrl),
+      ) ||
+      enterpriseHostPatterns.some((pattern) => pattern.test(hostname)) ||
+      enterprisePathPatterns.some((pattern) => pattern.test(pathname));
 
     if (isMatch) {
       console.log("[Pake] OAuth URL detected:", url);

--- a/tests/unit/auth-sso-patterns.test.js
+++ b/tests/unit/auth-sso-patterns.test.js
@@ -44,6 +44,27 @@ describe("auth SSO patterns", () => {
     expect(isAuthLink("https://example.com/reports/q3")).toBe(false);
   });
 
+  it("does not flag ordinary pages that merely contain sso or saml in the path", () => {
+    expect(isAuthLink("https://app.example.com/settings/sso/providers")).toBe(
+      false,
+    );
+    expect(isAuthLink("https://app.example.com/docs/saml/overview")).toBe(
+      false,
+    );
+  });
+
+  it("does not flag a query string that carries an SSO URL", () => {
+    expect(
+      isAuthLink(
+        "https://app.example.com/?next=https://idp.example.com/sso/saml",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not flag look-alike provider suffix hosts", () => {
+    expect(isAuthLink("https://okta.com.evil.test/app")).toBe(false);
+  });
+
   it("treats known auth window names as popups", () => {
     expect(isAuthPopup("https://example.com/dashboard", "oauth2")).toBe(true);
   });

--- a/tests/unit/event-link-guard.test.js
+++ b/tests/unit/event-link-guard.test.js
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { runInNewContext } from "node:vm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 function loadEventHelpers({
   withTauri = false,
@@ -17,6 +17,36 @@ function loadEventHelpers({
     invokeCalls.push([command, payload]);
     return Promise.resolve();
   };
+  const eventListeners = {};
+  const elementsById = new Map();
+  const registerListener = (type, handler, options) => {
+    eventListeners[type] = eventListeners[type] || [];
+    eventListeners[type].push({ handler, options });
+  };
+  const createElement = (tagName = "div") => ({
+    tagName: tagName.toUpperCase(),
+    style: {},
+    children: [],
+    addEventListener: () => {},
+    appendChild(child) {
+      this.children.push(child);
+      if (child.id) elementsById.set(child.id, child);
+    },
+    removeChild(child) {
+      this.children = this.children.filter((item) => item !== child);
+      if (child.id) elementsById.delete(child.id);
+    },
+    click: () => {},
+    set id(value) {
+      this._id = value;
+      elementsById.set(value, this);
+    },
+    get id() {
+      return this._id;
+    },
+  });
+  const body = createElement("body");
+  body.scrollHeight = 0;
 
   const context = {
     console,
@@ -45,26 +75,67 @@ function loadEventHelpers({
         getItem: () => null,
         setItem: () => {},
       },
-      addEventListener: () => {},
+      addEventListener: registerListener,
       dispatchEvent: () => {},
+      open: () => ({}),
+      isAuthLink: () => false,
+      isAuthPopup: () => false,
+      pakeConfig: {},
     },
     document: {
-      addEventListener: () => {},
+      addEventListener: registerListener,
+      createElement,
+      getElementById: (id) => elementsById.get(id) || null,
       getElementsByTagName: () => [{ style: {} }],
-      body: {
-        style: {},
-        scrollHeight: 0,
-      },
+      body,
       execCommand: () => {},
     },
   };
   context.window.navigator = context.navigator;
   if (withTauri) {
-    context.window.__TAURI__ = { core: { invoke } };
+    context.window.__TAURI__ = {
+      core: { invoke },
+      window: {
+        getCurrentWindow: () => ({
+          startDragging: () => {},
+          isFullscreen: () => Promise.resolve(false),
+          setFullscreen: () => {},
+        }),
+      },
+    };
   }
 
   runInNewContext(source, context);
-  return { ...context, invokeCalls };
+  return { ...context, eventListeners, invokeCalls };
+}
+
+function runDomReady(context) {
+  context.eventListeners.DOMContentLoaded[0].handler();
+}
+
+function getClickGuard(context) {
+  return context.eventListeners.click.find(
+    ({ handler }) => handler.name === "detectAnchorElementClick",
+  ).handler;
+}
+
+function makeAnchor(href, target = "_blank") {
+  return {
+    href,
+    target,
+    download: "",
+    getAttribute: (name) => (name === "href" ? href : ""),
+  };
+}
+
+function makeClickEvent(anchor) {
+  return {
+    target: {
+      closest: () => anchor,
+    },
+    preventDefault: vi.fn(),
+    stopImmediatePropagation: vi.fn(),
+  };
 }
 
 describe("event link guard", () => {
@@ -137,6 +208,42 @@ describe("event link guard", () => {
     ]);
     expect(window.location.href).toBe("https://example.com/app");
     expect(result).toBe(popup);
+  });
+
+  it("navigates target blank auth links in-place when new-window is disabled", () => {
+    const context = loadEventHelpers({ withTauri: true });
+    context.window.pakeConfig = { new_window: false };
+    context.window.isAuthLink = (url) => url.includes("okta.com");
+    runDomReady(context);
+
+    const event = makeClickEvent(
+      makeAnchor("https://mycompany.okta.com/sso", "_blank"),
+    );
+    getClickGuard(context)(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopImmediatePropagation).toHaveBeenCalled();
+    expect(context.window.location.href).toBe("https://mycompany.okta.com/sso");
+  });
+
+  it("navigates target blank internal links in-place when new-window is disabled", () => {
+    const context = loadEventHelpers({ withTauri: true });
+    context.window.pakeConfig = {
+      new_window: false,
+      internal_url_regex: "^https://app\\.example\\.com",
+    };
+    runDomReady(context);
+
+    const event = makeClickEvent(
+      makeAnchor("https://app.example.com/callback", "_blank"),
+    );
+    getClickGuard(context)(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopImmediatePropagation).toHaveBeenCalled();
+    expect(context.window.location.href).toBe(
+      "https://app.example.com/callback",
+    );
   });
 
   it("bridges Web Badging API calls to explicit badge commands", async () => {


### PR DESCRIPTION
## Problem

The enterprise SSO matchers used to keep sign-in flows in-app (Okta, OneLogin, SAML, SSO, ADFS) are tested against the entire URL. As a result, ordinary application pages are misclassified as authentication — their click handlers are stopped and navigation is forced. Examples:

- `/settings/sso/providers` (a settings page)
- `/docs/saml/overview` (a docs page)
- `https://app.example.com/?next=https://idp.example.com/sso/saml` (an SSO URL carried in a query string)

## Changes

- **Scope the matching.** Identity providers (Okta, OneLogin) are matched on the hostname; SAML/SSO/ADFS are matched on the pathname with endpoint-shaped patterns (`/saml/acs`, `/sso/redirect`, `/adfs/ls`, …). Ordinary pages and query strings no longer trigger auth handling. The existing `oauthPatterns` are left unchanged.
- **Document `--safe-domain`.** Add it to the EN/CN CLI reference: host-bound semantics, precedence vs `--internal-url-regex`, and an example.

## Tests

Adds false-positive coverage (settings/docs paths, a query-carried SSO URL, a look-alike suffix host such as `okta.com.evil.test`) alongside the existing provider/endpoint cases. Full Vitest suite passes; Prettier check clean.

## Test plan

```
pake https://app.slack.com --safe-domain slack.com,okta.com
```

SSO sign-in stays inside the app window. Navigating to an in-app `/settings/sso/...` page now behaves normally instead of being hijacked as an authentication redirect.
