### PR TITLE
feat: support cross-platform dark mode on Windows and Linux

### DIFF
--- a/bin/helpers/cli-program.ts
+++ b/bin/helpers/cli-program.ts
@@ -103,7 +103,7 @@ ${green('|_|   \\__,_|_|\\_\\___|  can turn any webpage into a desktop app with 
         .hideHelp(),
     )
     .addOption(
-      new Option('--dark-mode', 'Force Mac app to use dark mode')
+      new Option('--dark-mode', 'Force app to use dark mode (supports macOS, Windows, and Linux)')
         .default(DEFAULT.darkMode)
         .hideHelp(),
     )

--- a/bin/types.ts
+++ b/bin/types.ts
@@ -38,7 +38,7 @@ export interface PakeCliOptions {
   // App version, the same as package.json version, default 1.0.0
   appVersion: string;
 
-  // Force Mac to use dark mode, default false
+  // Force app to use dark mode (supports macOS, Windows, and Linux), default false
   darkMode: boolean;
 
   // Disable web shortcuts, default false

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -2685,7 +2685,7 @@ ${green('|_|   \\__,_|_|\\_\\___|  can turn any webpage into a desktop app with 
         .addOption(new Option('--maximize', 'Start window maximized')
         .default(DEFAULT_PAKE_OPTIONS.maximize)
         .hideHelp())
-        .addOption(new Option('--dark-mode', 'Force Mac app to use dark mode')
+        .addOption(new Option('--dark-mode', 'Force app to use dark mode (supports macOS, Windows, and Linux)')
         .default(DEFAULT_PAKE_OPTIONS.darkMode)
         .hideHelp())
         .addOption(new Option('--disabled-web-shortcuts', 'Disabled webPage shortcuts')

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -218,7 +218,7 @@ Set the version number of the packaged application to be consistent with the nam
 
 #### [dark-mode]
 
-Force Mac to package applications using dark mode, default is `false`.
+Force packaging applications using dark mode (supports macOS, Windows, and Linux), default is `false`.
 
 ```shell
 --dark-mode

--- a/docs/cli-usage_CN.md
+++ b/docs/cli-usage_CN.md
@@ -216,7 +216,7 @@ pake https://github.com --name GitHub
 
 #### [dark-mode]
 
-强制 Mac 打包应用使用黑暗模式，默认为 `false`。
+强制打包应用使用黑暗模式（支持 macOS、Windows 和 Linux），默认为 `false`。
 
 ```shell
 --dark-mode

--- a/src-tauri/src/app/invoke.rs
+++ b/src-tauri/src/app/invoke.rs
@@ -7,7 +7,6 @@ use tauri::http::Method;
 use tauri::{command, AppHandle, Manager, Url, WebviewWindow};
 use tauri_plugin_http::reqwest::{ClientBuilder, Request};
 
-#[cfg(target_os = "macos")]
 use tauri::Theme;
 
 static BADGE_COUNT: AtomicI64 = AtomicI64::new(0);
@@ -183,21 +182,13 @@ pub fn set_dock_badge_label(app: AppHandle, label: Option<String>) -> Result<(),
 
 #[command]
 pub async fn update_theme_mode(app: AppHandle, mode: String) {
-    #[cfg(target_os = "macos")]
-    {
-        if let Some(window) = app.get_webview_window("pake") {
-            let theme = if mode == "dark" {
-                Theme::Dark
-            } else {
-                Theme::Light
-            };
-            let _ = window.set_theme(Some(theme));
-        }
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = app;
-        let _ = mode;
+    if let Some(window) = app.get_webview_window("pake") {
+        let theme = if mode == "dark" {
+            Theme::Dark
+        } else {
+            Theme::Light
+        };
+        let _ = window.set_theme(Some(theme));
     }
 }
 

--- a/src-tauri/src/app/window.rs
+++ b/src-tauri/src/app/window.rs
@@ -12,8 +12,10 @@ use tauri::{
     AppHandle, Config, Manager, Url, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
 };
 
+use tauri::Theme;
+
 #[cfg(target_os = "macos")]
-use tauri::{Theme, TitleBarStyle};
+use tauri::TitleBarStyle;
 
 #[cfg(target_os = "windows")]
 fn build_proxy_browser_arg(url: &Url) -> Option<String> {
@@ -366,7 +368,12 @@ fn build_window(
     // Windows and Linux: set data_directory before proxy_url
     #[cfg(not(target_os = "macos"))]
     {
-        window_builder = window_builder.data_directory(_data_dir).theme(None);
+        let theme = if window_config.dark_mode {
+            Some(Theme::Dark)
+        } else {
+            None // Follow system theme
+        };
+        window_builder = window_builder.data_directory(_data_dir).theme(theme);
 
         if !config.proxy_url.is_empty() {
             if let Ok(proxy_url) = Url::from_str(&config.proxy_url) {


### PR DESCRIPTION
### Description
This PR resolves the limitation where `--dark-mode` initialization and dynamic theme synchronization (`update_theme_mode`) were restricted only to macOS. It extends support for dark theme synchronization and forced dark mode to Windows and Linux (tested and verified on Fedora 44) using Tauri's native, cross-platform theme API.

### Changes
1. **Unconditional `tauri::Theme` import**: Removed macOS-only compilation guards (`#[cfg(target_os = "macos")]) around `Theme` imports in both `window.rs` and `invoke.rs`.
2. **Cross-platform initialization**: Updated window builder configuration on Windows/Linux to honor the `dark_mode` preference dynamically using `.theme(theme)` instead of forcing `.theme(None)`.
3. **Cross-platform dynamic setting**: Updated the `update_theme_mode` command handler to call `window.set_theme` on all target platforms, eliminating OS-specific guards.
4. **Documentation**: Updated `--dark-mode` descriptions in the CLI parser configuration and user documentation (`docs/cli-usage.md` and `docs/cli-usage_CN.md`) to explicitly denote macOS, Windows, and Linux support.

### Verification
- Tested and verified at runtime on Fedora 44 that launching the app with `--dark-mode` sets the window theme to dark correctly.
- All 12 Rust Cargo tests compiled and passed.
- All 193 Vitest CLI tests passed successfully.

Closes #1244