### PR TITLE
feat: honour --targets app on macOS for app-only builds

### DIFF
--- a/bin/builders/MacBuilder.ts
+++ b/bin/builders/MacBuilder.ts
@@ -15,7 +15,9 @@ export default class MacBuilder extends BaseBuilder {
       ? options.targets
       : 'auto';
 
+    // `app` is a valid macOS bundle target (see merge.ts); honour it explicitly.
     if (
+      options.targets === 'app' ||
       options.iterativeBuild ||
       options.install ||
       process.env.PAKE_CREATE_APP === '1'

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -1272,7 +1272,9 @@ class MacBuilder extends BaseBuilder {
         this.buildArch = validArchs.includes(options.targets || '')
             ? options.targets
             : 'auto';
-        if (options.iterativeBuild ||
+        // `app` is a valid macOS bundle target (see merge.ts); honour it explicitly.
+        if (options.targets === 'app' ||
+            options.iterativeBuild ||
             options.install ||
             process.env.PAKE_CREATE_APP === '1') {
             this.buildFormat = 'app';

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -308,7 +308,7 @@ Specify the build target architecture or format:
 
 - **Linux**: `deb`, `appimage`, `rpm`, `zst`, `deb-arm64`, `appimage-arm64`, `rpm-arm64`, `zst-arm64` (default: `deb`, `appimage`)
 - **Windows**: `x64`, `arm64` (auto-detects if not specified)
-- **macOS**: `intel`, `apple`, `universal` (auto-detects if not specified)
+- **macOS**: `intel`, `apple`, `universal` (architecture, auto-detects if not specified); `app`, `dmg` (output format, default: `dmg`)
 
 ```shell
 --targets <target>
@@ -319,6 +319,8 @@ Specify the build target architecture or format:
 --targets universal      # macOS Universal (Intel + Apple Silicon)
 --targets apple          # macOS Apple Silicon only
 --targets intel          # macOS Intel only
+--targets app            # macOS app bundle only (.app, skips the DMG step)
+--targets dmg            # macOS DMG installer (default)
 --targets deb            # Linux DEB package (x64)
 --targets rpm            # Linux RPM package (x64)
 --targets appimage       # Linux AppImage (x64)

--- a/docs/cli-usage_CN.md
+++ b/docs/cli-usage_CN.md
@@ -306,7 +306,7 @@ pake https://github.com --name GitHub
 
 - **Linux**: `deb`, `appimage`, `rpm`, `zst`, `deb-arm64`, `appimage-arm64`, `rpm-arm64`, `zst-arm64`（默认：`deb`, `appimage`）
 - **Windows**: `x64`, `arm64`（未指定时自动检测）
-- **macOS**: `intel`, `apple`, `universal`（未指定时自动检测）
+- **macOS**: `intel`, `apple`, `universal`（架构，未指定时自动检测）；`app`, `dmg`（输出格式，默认：`dmg`）
 
 ```shell
 --targets <target>
@@ -317,6 +317,8 @@ pake https://github.com --name GitHub
 --targets universal      # macOS 通用版本（Intel + Apple Silicon）
 --targets apple          # 仅 macOS Apple Silicon
 --targets intel          # 仅 macOS Intel
+--targets app            # 仅 macOS 应用包（.app，跳过 DMG 步骤）
+--targets dmg            # macOS DMG 安装包（默认）
 --targets deb            # Linux DEB 包（x64）
 --targets rpm            # Linux RPM 包（x64）
 --targets appimage       # Linux AppImage（x64）

--- a/tests/unit/mac-builder-targets.test.ts
+++ b/tests/unit/mac-builder-targets.test.ts
@@ -1,0 +1,38 @@
+import path from 'path';
+import { describe, it, expect, vi } from 'vitest';
+
+// tauriConfig.ts reads pake.json at module load, keyed off npmDirectory.
+// Point it at the repo root so the import chain resolves under vitest.
+vi.mock('@/utils/dir', () => ({
+  npmDirectory: process.cwd(),
+  tauriConfigDirectory: path.join(process.cwd(), 'src-tauri', '.pake'),
+}));
+
+import MacBuilder from '@/builders/MacBuilder';
+import { PakeAppOptions } from '@/types';
+
+const makeBuilder = (targets?: string) =>
+  new MacBuilder({ name: 'Demo', targets } as PakeAppOptions);
+
+describe('MacBuilder target selection', () => {
+  it('builds an app bundle when --targets app is requested', () => {
+    // The app format ships a bare `.app`, so the file name carries no
+    // version/arch suffix. This proves `--targets app` is honoured rather
+    // than silently coerced to the default DMG.
+    expect(makeBuilder('app').getFileName()).toBe('Demo');
+  });
+
+  it('builds a DMG when --targets dmg is requested', () => {
+    expect(makeBuilder('dmg').getFileName()).toMatch(/^Demo_.+/);
+  });
+
+  it('defaults to a DMG when no target is given', () => {
+    expect(makeBuilder(undefined).getFileName()).toMatch(/^Demo_.+/);
+  });
+
+  it('keeps treating arch values as DMG builds with an arch suffix', () => {
+    expect(makeBuilder('apple').getFileName()).toMatch(/_aarch64$/);
+    expect(makeBuilder('intel').getFileName()).toMatch(/_x64$/);
+    expect(makeBuilder('universal').getFileName()).toMatch(/_universal$/);
+  });
+});


### PR DESCRIPTION
## What

On macOS, `pake <url> --targets app` always produced a `.dmg` instead of an app-only build. This makes `--targets app` actually build only the `.app` bundle, skipping the DMG packaging step.

## Why

`merge.ts` already treats `app` as a valid macOS bundle target (`validMacTargets = ['app', 'dmg']`), but `MacBuilder`'s constructor set `buildFormat` to `dmg` for any value that wasn't an arch — and then overwrote `options.targets` with it before `mergeConfig` could apply the `app` target. So the `app` branch in `merge.ts` was unreachable.

Building the DMG also mounts a volume window and adds noticeable time, which is unnecessary when you only want the `.app`.

## How

Treat an explicit `--targets app` the same way `--install` and `iterativeBuild` already request the `app` format in the constructor.

## Tests

Adds `tests/unit/mac-builder-targets.test.ts`: `--targets app` yields an app-only filename; `dmg`/default/arch values still resolve to DMG builds. Full suite: 174 passing.

## Docs

Documents `app`/`dmg` as macOS output formats in `docs/cli-usage.md` and `docs/cli-usage_CN.md`.
