### PR TITLE
fix(ci): match Linux artifacts by extension, not raw input name

### DIFF
--- a/.github/workflows/pake-cli.yaml
+++ b/.github/workflows/pake-cli.yaml
@@ -210,7 +210,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.name }}-Linux-deb
-          path: ${{ inputs.name }}.deb
+          path: "*.deb"
           retention-days: 3
           if-no-files-found: ignore
 
@@ -219,7 +219,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.name }}-Linux-AppImage
-          path: ${{ inputs.name }}.AppImage
+          path: "*.AppImage"
           retention-days: 3
           if-no-files-found: ignore
 
@@ -228,7 +228,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.name }}-Linux-rpm
-          path: ${{ inputs.name }}.rpm
+          path: "*.rpm"
           retention-days: 3
           if-no-files-found: ignore
 
@@ -237,7 +237,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.name }}-Linux-zst
-          path: ${{ inputs.name }}-*.pkg.tar.zst
+          path: "*.pkg.tar.zst"
           retention-days: 3
           if-no-files-found: ignore
 


### PR DESCRIPTION
The Linux upload steps looked for ${{ inputs.name }}.deb (etc.), but the Pake CLI rewrites the app name on Linux via generateLinuxPackageName() (lowercase, non-alphanumeric -> '-', trimmed dashes) before writing <normalized-name>.deb. When the dispatched name was not already a valid lowercase-dash package name, the produced file never matched the upload glob. Combined with if-no-files-found: ignore, the steps succeeded while uploading 0 artifacts.

Match by extension (*.deb, *.AppImage, *.rpm, *.pkg.tar.zst) so the upload no longer depends on predicting the normalized filename. The artifact download label still uses inputs.name.