### PR TITLE
fix: exclude FULLSCREEN from window state tracking when not using --fullscreen

### DIFF
--- a/src-tauri/src/app/setup.rs
+++ b/src-tauri/src/app/setup.rs
@@ -61,7 +61,12 @@ pub fn set_system_tray(
                 }
             }
             "quit" => {
-                let _ = app.save_window_state(StateFlags::all());
+                let flags = if _init_fullscreen {
+                    StateFlags::all()
+                } else {
+                    StateFlags::all() & !StateFlags::FULLSCREEN
+                };
+                let _ = app.save_window_state(flags);
                 app.exit(0);
             }
             _ => (),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -155,7 +155,9 @@ pub fn run_app() {
             StateFlags::FULLSCREEN
         } else {
             // Prevent flickering on the first open.
-            StateFlags::all() & !StateFlags::VISIBLE
+            // Exclude FULLSCREEN so a prior --fullscreen build's persisted state
+            // doesn't force fullscreen on a rebuild without --fullscreen.
+            StateFlags::all() & !StateFlags::VISIBLE & !StateFlags::FULLSCREEN
         })
         .build();
 


### PR DESCRIPTION
When --fullscreen is not set, the WindowStatePlugin was still configured
with StateFlags::all() which includes FULLSCREEN. This caused a prior
build's fullscreen state (persisted in AppData) to be restored on launch,
overriding the fullscreen: false config from pake.json. Uninstalling the
app does not clear the persisted state file, so rebuilding without
--fullscreen had no effect.

Changes:
- lib.rs: exclude FULLSCREEN from state flags in the else branch so the
  plugin neither saves nor restores fullscreen state when the app is not
  built with --fullscreen
- setup.rs: conditionally exclude FULLSCREEN from the tray quit handler's
  save_window_state call, matching the plugin initialization logic

Closes #1259
