### PR TITLE
fix: clipboard copy-paste support on Linux and Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ src-tauri/icons/testapp.icns
 src-tauri/icons/localapp.icns
 src-tauri/icons/urltest.icns
 src-tauri/icons/githubmultiarch.icns
+# Local AI runtime state
+.atl/

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -48,6 +48,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +475,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +637,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -810,6 +846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +971,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +1004,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1033,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1497,6 +1557,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,6 +1886,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2256,6 +2328,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2573,6 +2654,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-http",
  "tauri-plugin-notification",
@@ -2649,6 +2731,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+]
 
 [[package]]
 name = "phf"
@@ -3000,6 +3093,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,6 +3112,15 @@ name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -3069,7 +3177,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4169,6 +4277,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-fs"
 version = "2.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4514,6 +4637,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4810,6 +4947,17 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
 ]
 
 [[package]]
@@ -5143,6 +5291,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5250,6 +5468,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -5813,6 +6037,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6076,6 +6318,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ tauri-plugin-shell = { version = "2.3.5" }
 tauri-plugin-opener = { version = "2.5.3" }
 tauri-plugin-single-instance = "2.4.0"
 tauri-plugin-notification = "2.3.3"
+tauri-plugin-clipboard-manager = "2.2.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -24,6 +24,7 @@
     "notification:allow-register-listener",
     "notification:allow-register-action-types",
     "notification:default",
-    "core:path:default"
+    "core:path:default",
+    "clipboard-manager:allow-read-text"
   ]
 }

--- a/src-tauri/src/inject/event.js
+++ b/src-tauri/src/inject/event.js
@@ -345,6 +345,61 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
+  // Keyboard shortcut bridge for clipboard operations (Windows and Linux only)
+  if (/windows|linux/i.test(navigator.userAgent)) {
+    document.addEventListener("keydown", (e) => {
+      const isCtrl = e.ctrlKey || e.metaKey;
+      if (!isCtrl) return;
+
+      const activeEl = document.activeElement;
+      if (!activeEl) return;
+
+      const isInput = activeEl.tagName === "INPUT" ||
+                      activeEl.tagName === "TEXTAREA" ||
+                      activeEl.isContentEditable;
+
+      const key = e.key.toLowerCase();
+
+      if (key === "c") {
+        if (isInput || window.getSelection().toString()) {
+          document.execCommand("copy");
+          e.preventDefault();
+        }
+      } else if (key === "x") {
+        if (isInput) {
+          document.execCommand("cut");
+          e.preventDefault();
+        }
+      } else if (key === "v") {
+        if (isInput) {
+          e.preventDefault();
+          window.__TAURI__?.core?.invoke("plugin:clipboard-manager|read_text")
+            .then((text) => {
+              if (text) {
+                document.execCommand("insertText", false, text);
+              }
+            })
+            .catch((err) => {
+              console.error("Failed to paste from clipboard:", err);
+            });
+        }
+      } else if (key === "a") {
+        if (isInput) {
+          if (typeof activeEl.select === "function") {
+            activeEl.select();
+          } else {
+            const range = document.createRange();
+            range.selectNodeContents(activeEl);
+            const selection = window.getSelection();
+            selection.removeAllRanges();
+            selection.addRange(range);
+          }
+          e.preventDefault();
+        }
+      }
+    });
+  }
+
   document.addEventListener(
     "paste",
     (event) => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -168,7 +168,8 @@ pub fn run_app() {
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_notification::init())
-        .plugin(tauri_plugin_opener::init()); // Add this
+        .plugin(tauri_plugin_opener::init()) // Add this
+        .plugin(tauri_plugin_clipboard_manager::init());
 
     // Only add single instance plugin if multiple instances are not allowed
     if !multi_instance {

--- a/tests/unit/event-shortcuts.test.js
+++ b/tests/unit/event-shortcuts.test.js
@@ -1,0 +1,216 @@
+import fs from "fs";
+import path from "path";
+import { runInNewContext } from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+
+function loadEventHelpers({
+  withTauri = false,
+  userAgent = "Mozilla/5.0",
+} = {}) {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), "src-tauri/src/inject/event.js"),
+    "utf-8",
+  );
+
+  const invokeCalls = [];
+  const clipboardText = "mocked clipboard text";
+  const invoke = (command, payload) => {
+    invokeCalls.push([command, payload]);
+    if (command === "plugin:clipboard-manager|read_text") {
+      return Promise.resolve(clipboardText);
+    }
+    return Promise.resolve();
+  };
+  const eventListeners = {};
+  const elementsById = new Map();
+  const registerListener = (type, handler, options) => {
+    eventListeners[type] = eventListeners[type] || [];
+    eventListeners[type].push({ handler, options });
+  };
+  
+  const execCommandCalls = [];
+  const execCommand = (command, showUI, value) => {
+    execCommandCalls.push([command, showUI, value]);
+    return true;
+  };
+
+  const createElement = (tagName = "div") => {
+    const el = {
+      tagName: tagName.toUpperCase(),
+      style: {},
+      children: [],
+      addEventListener: () => {},
+      appendChild(child) {
+        this.children.push(child);
+        if (child.id) elementsById.set(child.id, child);
+      },
+      removeChild(child) {
+        this.children = this.children.filter((item) => item !== child);
+        if (child.id) elementsById.delete(child.id);
+      },
+      set id(value) {
+        this._id = value;
+        elementsById.set(value, this);
+      },
+      get id() {
+        return this._id;
+      },
+    };
+    return el;
+  };
+
+  const body = createElement("body");
+
+  const activeElement = {
+    tagName: "INPUT",
+    isContentEditable: false,
+    select: vi.fn(),
+  };
+
+  const context = {
+    console,
+    URL,
+    Event: class {},
+    Notification: function Notification() {},
+    setTimeout,
+    clearTimeout,
+    scrollTo: () => {},
+    navigator: {
+      userAgent,
+      language: "en-US",
+    },
+    window: {
+      history: {
+        back: () => {},
+        forward: () => {},
+      },
+      location: {
+        href: "https://example.com/app",
+        origin: "https://example.com",
+        pathname: "/app",
+        reload: () => {},
+      },
+      localStorage: {
+        getItem: () => null,
+        setItem: () => {},
+      },
+      addEventListener: registerListener,
+      dispatchEvent: () => {},
+      open: () => ({}),
+      isAuthLink: () => false,
+      isAuthPopup: () => false,
+      pakeConfig: {},
+    },
+    document: {
+      addEventListener: registerListener,
+      createElement,
+      getElementById: (id) => elementsById.get(id) || null,
+      getElementsByTagName: () => [{ style: {} }],
+      body,
+      activeElement,
+      execCommand,
+    },
+  };
+  context.window.navigator = context.navigator;
+  if (withTauri) {
+    context.window.__TAURI__ = {
+      core: { invoke },
+      window: {
+        getCurrentWindow: () => ({
+          startDragging: () => {},
+          isFullscreen: () => Promise.resolve(false),
+          setFullscreen: () => {},
+        }),
+      },
+    };
+  }
+
+  runInNewContext(source, context);
+  return { ...context, eventListeners, invokeCalls, execCommandCalls, activeElement };
+}
+
+function runDomReady(context) {
+  if (context.eventListeners.DOMContentLoaded) {
+    context.eventListeners.DOMContentLoaded[0].handler();
+  }
+}
+
+describe("event keyboard shortcuts bridge", () => {
+  it("intercepts Ctrl+C/V/X/A on Windows/Linux", async () => {
+    const context = loadEventHelpers({
+      withTauri: true,
+      userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    });
+    runDomReady(context);
+
+    const keydownListeners = context.eventListeners.keydown || [];
+    // We expect our keydown listener to be registered on document
+    const bridgeListener = keydownListeners.find(({ handler }) => {
+      return handler.toString().includes("insertText") || handler.toString().includes("clipboard-manager");
+    });
+
+    expect(bridgeListener).toBeDefined();
+
+    const { handler } = bridgeListener;
+
+    // Test Ctrl+C
+    const eventC = {
+      key: "c",
+      ctrlKey: true,
+      preventDefault: vi.fn(),
+    };
+    handler(eventC);
+    expect(context.execCommandCalls).toContainEqual(["copy", undefined, undefined]);
+    expect(eventC.preventDefault).toHaveBeenCalled();
+
+    // Test Ctrl+X
+    const eventX = {
+      key: "x",
+      ctrlKey: true,
+      preventDefault: vi.fn(),
+    };
+    handler(eventX);
+    expect(context.execCommandCalls).toContainEqual(["cut", undefined, undefined]);
+    expect(eventX.preventDefault).toHaveBeenCalled();
+
+    // Test Ctrl+A
+    const eventA = {
+      key: "a",
+      ctrlKey: true,
+      preventDefault: vi.fn(),
+    };
+    handler(eventA);
+    expect(context.activeElement.select).toHaveBeenCalled();
+    expect(eventA.preventDefault).toHaveBeenCalled();
+
+    // Test Ctrl+V
+    const eventV = {
+      key: "v",
+      ctrlKey: true,
+      preventDefault: vi.fn(),
+    };
+    handler(eventV);
+    expect(eventV.preventDefault).toHaveBeenCalled();
+    expect(context.invokeCalls).toContainEqual(["plugin:clipboard-manager|read_text", undefined]);
+
+    // Let the promise resolve to check insertText execution
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(context.execCommandCalls).toContainEqual(["insertText", false, "mocked clipboard text"]);
+  });
+
+  it("does not intercept Ctrl+C/V/X/A on macOS", () => {
+    const context = loadEventHelpers({
+      withTauri: true,
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    });
+    runDomReady(context);
+
+    const keydownListeners = context.eventListeners.keydown || [];
+    const bridgeListener = keydownListeners.find(({ handler }) => {
+      return handler.toString().includes("insertText") || handler.toString().includes("clipboard-manager");
+    });
+
+    // On macOS, we should NOT define the keydown bridge listener
+    expect(bridgeListener).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Description

Resolves the limitation where keyboard shortcuts for clipboard operations (`Ctrl+C`, `Ctrl+X`, `Ctrl+V`, `Ctrl+A`) did not work inside Pake webviews on Linux and Windows.

On macOS, `src-tauri/src/app/menu.rs` already provides a native `Edit` menu with `PredefinedMenuItem::copy` / `cut` / `paste` / `select_all`, and the OS routes the accelerators to the focused webview. Linux and Windows have no such native menu, so the system never translated the accelerator and the webview never saw the event.

This PR adds a small JS keyboard-event bridge in the injected bundle (`src-tauri/src/inject/event.js`) that is gated to non-macOS platforms and intercepts the same accelerators, dispatching the equivalent `document.execCommand` calls and reading from the OS clipboard through the new `tauri-plugin-clipboard-manager` plugin for paste.

### Changes

| File | Change |
|------|--------|
| `src-tauri/Cargo.toml` / `Cargo.lock` | Add `tauri-plugin-clipboard-manager = "2.2.0"` |
| `src-tauri/src/lib.rs` | Register `tauri_plugin_clipboard_manager::init()` in the builder |
| `src-tauri/capabilities/default.json` | Grant `clipboard-manager:allow-read-text` |
| `src-tauri/src/inject/event.js` | Add a `Ctrl+C` / `Ctrl+X` / `Ctrl+V` / `Ctrl+A` bridge restricted to non-macOS |
| `tests/unit/event-shortcuts.test.js` | Unit tests covering the bridge and macOS skip path |

### Verification

- `cargo check --manifest-path src-tauri/Cargo.toml`: clean
- `npx vitest run tests/unit/event-shortcuts.test.js`: 2/2 passing
- End-to-end tested on Linux (WebKitGTK) via `pnpm run dev`:
  - `Ctrl+C` on selected page text copies to the OS clipboard
  - `Ctrl+X` cuts the selected text
  - `Ctrl+A` in a text input selects all
  - `Ctrl+V` pastes from the OS clipboard into the focused input
- Existing Pake build pipeline (`.deb` / `.AppImage` / `.msi`) is unchanged: no new build-time options or flags were added.

Closes #1267
