### PR TITLE
Keep SPA internal target=_blank links inside the app

### DIFF
--- a/src-tauri/src/inject/event.js
+++ b/src-tauri/src/inject/event.js
@@ -486,13 +486,19 @@ document.addEventListener("DOMContentLoaded", () => {
 
         if (isInternalUrl(absoluteUrl)) {
           // With --new-window the Rust on_new_window handler opens an in-app
-          // window; without it, deferring to the native handler sends the
-          // _blank target to the system browser and strands SSO callbacks.
-          // Navigate in place so internal links stay inside the webview.
+          // window. Without it, leaving target="_blank" untouched lets the
+          // native webview escalate the click to a system-browser "new window".
+          //
+          // Many SPAs (e.g. Plane) tag in-app links with target="_blank" but
+          // route the click themselves via a React onClick that calls
+          // preventDefault + client-side navigation. Forcing a full
+          // window.location reload here (and stopping propagation) would defeat
+          // that handler and reload the whole app on every click. Instead,
+          // retarget the link to "_self" so the webview never opens a browser
+          // window, then let the page's own handler run. If nothing intercepts
+          // the click, the default _self navigation keeps it inside the app.
           if (!window.pakeConfig?.new_window) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-            window.location.href = absoluteUrl;
+            anchorElement.target = "_self";
           }
           return;
         }

--- a/tests/unit/event-link-guard.test.js
+++ b/tests/unit/event-link-guard.test.js
@@ -226,7 +226,7 @@ describe("event link guard", () => {
     expect(context.window.location.href).toBe("https://mycompany.okta.com/sso");
   });
 
-  it("navigates target blank internal links in-place when new-window is disabled", () => {
+  it("retargets internal target=_blank links to _self instead of forcing a reload", () => {
     const context = loadEventHelpers({ withTauri: true });
     context.window.pakeConfig = {
       new_window: false,
@@ -234,16 +234,34 @@ describe("event link guard", () => {
     };
     runDomReady(context);
 
-    const event = makeClickEvent(
-      makeAnchor("https://app.example.com/callback", "_blank"),
-    );
+    const anchor = makeAnchor("https://app.example.com/callback", "_blank");
+    const event = makeClickEvent(anchor);
+    getClickGuard(context)(event);
+
+    // The link must be neutralized so the native webview never opens a system
+    // browser window, but the page's own click handler (and a normal in-app
+    // navigation) should still run -- so we do NOT preventDefault / reload.
+    expect(anchor.target).toBe("_self");
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(context.window.location.href).toBe("https://example.com/app");
+  });
+
+  it("still opens external target=_blank links in the system browser", () => {
+    const context = loadEventHelpers({ withTauri: true });
+    context.window.pakeConfig = { new_window: false };
+    runDomReady(context);
+
+    const anchor = makeAnchor("https://other.example.org/page", "_blank");
+    const event = makeClickEvent(anchor);
     getClickGuard(context)(event);
 
     expect(event.preventDefault).toHaveBeenCalled();
     expect(event.stopImmediatePropagation).toHaveBeenCalled();
-    expect(context.window.location.href).toBe(
-      "https://app.example.com/callback",
-    );
+    expect(context.invokeCalls).toContainEqual([
+      "plugin:shell|open",
+      { path: "https://other.example.org/page" },
+    ]);
   });
 
   it("bridges Web Badging API calls to explicit badge commands", async () => {


### PR DESCRIPTION
Opening a project or expanding a task (the peek view) in a self-hosted Plane instance launched the system browser instead of navigating inside the Pake window. The same problem affects any single-page app that follows this pattern.

The cause is how these apps build their links. Plane (via its `ControlLink` component) puts `target="_blank"` on in-app links and then handles the click itself in JavaScript, calling `preventDefault` and doing client-side routing. So these are ordinary same-origin internal links that only look like "open in a new tab".

The webview opens any unhandled `target="_blank"` navigation in the system browser by default. To compensate, the injected link guard in `event.js` intercepted internal `_blank` links, forced a full `window.location.href` reload, and called `stopImmediatePropagation`. That stop call defeated the page's own click handler, and the click could still reach the native new-window path, so the link ended up in the browser instead of the app.

The fix: for internal `target="_blank"` links (when `--new-window` is not used), retarget the anchor to `_self` and let the event proceed normally. The webview no longer escalates the click to a browser window, the page's own handler still runs so the SPA navigation and peek view work as intended, and a link without any handler falls back to a normal in-app `_self` navigation. External `_blank` links, OAuth/SSO handling, and the `--new-window` path are all unchanged.

## How it was tested

- Reproduced and confirmed the fix against a real self-hosted Plane instance: opening projects and expanding tasks now stays in the app.
- Updated `tests/unit/event-link-guard.test.js` to cover the new behavior (internal `_blank` retargeted to `_self`, no forced reload) and added a test confirming external `_blank` links still open in the system browser.
- Full unit suite passes (206 tests).

## Files changed

- `src-tauri/src/inject/event.js`
- `tests/unit/event-link-guard.test.js`
