### PR TITLE
fix: keep injected JS wrapper valid when the file ends in a line comment

### DIFF
--- a/bin/utils/combine.ts
+++ b/bin/utils/combine.ts
@@ -14,10 +14,14 @@ export default async function combineFiles(files: string[], output: string) {
       }
 
       const fileContent = await fs.readFile(file);
+      // Keep the closing `});` on its own line. If the injected file ends in a
+      // line comment without a trailing newline, appending ` });` on the same
+      // line would comment it out and break the wrapper (mirrors the .css
+      // branch above, which already closes on a separate line).
       return (
-        "window.addEventListener('DOMContentLoaded', (_event) => { " +
+        "window.addEventListener('DOMContentLoaded', (_event) => {\n" +
         fileContent +
-        ' });'
+        '\n});'
       );
     }),
   );

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -435,9 +435,13 @@ async function combineFiles(files, output) {
       });`;
         }
         const fileContent = await fs$1.readFile(file);
-        return ("window.addEventListener('DOMContentLoaded', (_event) => { " +
+        // Keep the closing `});` on its own line. If the injected file ends in a
+        // line comment without a trailing newline, appending ` });` on the same
+        // line would comment it out and break the wrapper (mirrors the .css
+        // branch above, which already closes on a separate line).
+        return ("window.addEventListener('DOMContentLoaded', (_event) => {\n" +
             fileContent +
-            ' });');
+            '\n});');
     }));
     await fs$1.writeFile(output, contents.join('\n'));
     return files;

--- a/tests/unit/combine.test.ts
+++ b/tests/unit/combine.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import combineFiles from '../../bin/utils/combine.js';
+
+describe('combineFiles', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pake-combine-'));
+  });
+
+  afterAll(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('keeps the wrapper valid when a .js file ends in a line comment without a trailing newline', async () => {
+    const jsFile = path.join(dir, 'inject.js');
+    const out = path.join(dir, 'out-js.js');
+    // No trailing newline after the line comment: the closing `});` must not be
+    // absorbed into the comment.
+    await fs.writeFile(
+      jsFile,
+      "console.log('pake');\n//# sourceMappingURL=inject.js.map",
+    );
+
+    await combineFiles([jsFile], out);
+    const result = await fs.readFile(out, 'utf-8');
+
+    // Compiles only if the arrow function and its call are both closed.
+    expect(() => new Function(result)).not.toThrow();
+    expect(result).toContain("addEventListener('DOMContentLoaded'");
+  });
+
+  it('wraps .css files as a style injection with the content JSON-encoded', async () => {
+    const cssFile = path.join(dir, 'inject.css');
+    const out = path.join(dir, 'out-css.js');
+    await fs.writeFile(cssFile, 'body { color: red; }');
+
+    await combineFiles([cssFile], out);
+    const result = await fs.readFile(out, 'utf-8');
+
+    expect(() => new Function(result)).not.toThrow();
+    expect(result).toContain('document.head.appendChild');
+    expect(result).toContain(JSON.stringify('body { color: red; }'));
+  });
+
+  it('returns the input file list', async () => {
+    const jsFile = path.join(dir, 'ret.js');
+    const out = path.join(dir, 'out-ret.js');
+    await fs.writeFile(jsFile, 'void 0;');
+
+    const returned = await combineFiles([jsFile], out);
+
+    expect(returned).toEqual([jsFile]);
+  });
+});


### PR DESCRIPTION
Closes #1276

### What

`combineFiles` wrapped each injected `.js` file as `"...=> { " + content + " });"`, putting the closing ` });` on the same line as the file's last line. When an injected file ends in a line comment without a trailing newline (e.g. a `//# sourceMappingURL=...` pragma), the ` });` is swallowed by that comment, leaving the arrow function and its `addEventListener(` call unterminated — which breaks that inject script and every script combined after it.

### Change

- **`bin/utils/combine.ts`** — emit the closing `});` on its own line (`"...=> {\n" + content + "\n});"`), mirroring the existing `.css` branch.
- **`tests/unit/combine.test.ts`** *(new)* — regression test for the trailing-line-comment case, plus coverage for `.css` style-injection wrapping and the function's return value.
- **`dist/cli.js`** — rebuilt via `pnpm run cli:build`.

### Verify

```bash
npx vitest run tests/unit/combine.test.ts
```

The regression test fails on `main` and passes with this change (verified locally by reverting just `combine.ts`). Full suite: 208 passed; `pnpm run format:check` clean.
