### PR TITLE
test: add unit coverage for bin/utils/url.ts helpers

### DIFF
--- a/tests/unit/url.test.ts
+++ b/tests/unit/url.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getDomain,
+  appendProtocol,
+  normalizeUrl,
+} from '../../bin/utils/url.js';
+
+describe('getDomain', () => {
+  it('returns the SLD for a bare domain', () => {
+    expect(getDomain('https://github.com')).toBe('github');
+  });
+
+  it('strips the www subdomain down to the SLD', () => {
+    expect(getDomain('https://www.google.com')).toBe('google');
+  });
+
+  it('strips an arbitrary subdomain down to the registrable SLD', () => {
+    expect(getDomain('https://weekly.tw93.fun')).toBe('tw93');
+  });
+
+  it('handles multi-part public suffixes via PSL', () => {
+    expect(getDomain('https://sub.example.co.uk')).toBe('example');
+  });
+
+  it('returns null when the URL has no protocol', () => {
+    expect(getDomain('github.com')).toBeNull();
+  });
+
+  it('returns null for a malformed URL', () => {
+    expect(getDomain('not a url')).toBeNull();
+  });
+
+  it('returns null for a single-label host such as localhost', () => {
+    expect(getDomain('https://localhost')).toBeNull();
+  });
+});
+
+describe('appendProtocol', () => {
+  it('leaves an already-schemed URL unchanged', () => {
+    expect(appendProtocol('https://github.com')).toBe('https://github.com');
+    expect(appendProtocol('http://localhost')).toBe('http://localhost');
+  });
+
+  it('prepends https:// to a bare host', () => {
+    expect(appendProtocol('github.com')).toBe('https://github.com');
+  });
+
+  it('leaves a bare host:port unchanged (WHATWG parses "localhost:" as a scheme)', () => {
+    // Documents a known parser quirk: new URL('localhost:3000') succeeds with
+    // scheme "localhost:", so the input is treated as already-schemed.
+    expect(appendProtocol('localhost:3000')).toBe('localhost:3000');
+  });
+});
+
+describe('normalizeUrl', () => {
+  it('normalizes a bare host by adding https://', () => {
+    expect(normalizeUrl('github.com')).toBe('https://github.com');
+  });
+
+  it('keeps a valid URL unchanged', () => {
+    expect(normalizeUrl('https://github.com')).toBe('https://github.com');
+  });
+
+  it('throws for input that yields an unparseable URL', () => {
+    // appendProtocol('') -> 'https://', which new URL() rejects.
+    expect(() => normalizeUrl('')).toThrow('is invalid');
+  });
+});


### PR DESCRIPTION
Closes #1278

### What

Adds `tests/unit/url.test.ts`, the first dedicated test file for `bin/utils/url.ts`. Previously only `safeDomainsToRegex` was covered (via `safe-domains.test.ts`); `getDomain`, `appendProtocol`, and `normalizeUrl` were untested.

### Coverage

- **`getDomain`** — bare domain, `www`/arbitrary subdomain stripping, multi-part public suffixes (`example.co.uk`), and the `null` paths (no protocol, malformed input, single-label `localhost`).
- **`appendProtocol`** — already-schemed URLs pass through; bare host gets `https://`; and the documented WHATWG quirk where `localhost:3000` is parsed as scheme `localhost:` and left unchanged.
- **`normalizeUrl`** — bare host normalization, valid URL passthrough, and the previously-uncovered **throw** branch.

Tests only — no change to `bin/`, so no `dist/cli.js` rebuild. All assertions characterize current behavior (verified against the live functions).

### Verify

```bash
npx vitest run tests/unit/url.test.ts
```

Full suite: 218 passed; `pnpm run format:check` clean.
