### PR TITLE
docs: document --camera and --microphone macOS entitlement flags

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -476,6 +476,28 @@ This option is macOS-only and is intended for local development or quick testing
 pake https://github.com --name GitHub --install
 ```
 
+#### [camera]
+
+Request camera access on macOS by adding the `com.apple.security.device.camera` entitlement to the packaged app. Default is `false`. macOS only; ignored on Windows and Linux. Useful for web apps that need webcam access, such as video calls or QR scanning.
+
+```shell
+--camera
+
+# Example: Package a video-call site with camera access
+pake https://meet.google.com --name Meet --camera
+```
+
+#### [microphone]
+
+Request microphone access on macOS by adding the `com.apple.security.device.audio-input` entitlement to the packaged app. Default is `false`. macOS only; ignored on Windows and Linux.
+
+```shell
+--microphone
+
+# Example: Combine camera and microphone for a conferencing app
+pake https://meet.google.com --name Meet --camera --microphone
+```
+
 #### [multi-instance]
 
 Allow the packaged app to run more than one instance at the same time. Default is `false`, which means launching a second instance simply focuses the existing window. Enable this when you need to open several windows of the same app simultaneously.

--- a/docs/cli-usage_CN.md
+++ b/docs/cli-usage_CN.md
@@ -474,6 +474,28 @@ pake https://github.com --name GitHub --keep-binary
 pake https://github.com --name GitHub --install
 ```
 
+#### [camera]
+
+在 macOS 上为打包应用请求摄像头权限，会添加 `com.apple.security.device.camera` entitlement。默认为 `false`。仅适用于 macOS，在 Windows 和 Linux 上会被忽略。适用于需要访问摄像头的网页应用，例如视频通话或扫码。
+
+```shell
+--camera
+
+# 示例：为视频通话站点打包并开启摄像头权限
+pake https://meet.google.com --name Meet --camera
+```
+
+#### [microphone]
+
+在 macOS 上为打包应用请求麦克风权限，会添加 `com.apple.security.device.audio-input` entitlement。默认为 `false`。仅适用于 macOS，在 Windows 和 Linux 上会被忽略。
+
+```shell
+--microphone
+
+# 示例：为会议类应用同时开启摄像头和麦克风权限
+pake https://meet.google.com --name Meet --camera --microphone
+```
+
 #### [multi-instance]
 
 允许打包后的应用同时运行多个实例。默认为 `false`，此时再次启动只会聚焦已有窗口。启用该选项后，可以同时打开同一个应用的多个窗口。


### PR DESCRIPTION
Closes #1280

### What

`--camera` and `--microphone` are functional CLI flags (they add macOS `com.apple.security.device.camera` / `com.apple.security.device.audio-input` entitlements via `generateMacEntitlements()` in `bin/helpers/merge.ts`) but were absent from the complete CLI reference. `AGENTS.md` requires every CLI parameter to be documented in `docs/cli-usage*.md`.

### Change

- **`docs/cli-usage.md`** — add `#### [camera]` and `#### [microphone]` sections.
- **`docs/cli-usage_CN.md`** — same sections with Simplified Chinese prose (headings kept in English, consistent with the rest of the file).

Both are placed next to the existing macOS-only `[install]` section. Docs-only; no code change.

### Verify

```bash
grep -niE 'camera|microphone' docs/cli-usage.md docs/cli-usage_CN.md
```

`pnpm run format:check` is clean.
