### PR TITLE
docs: fix broken window-options anchor in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -439,7 +439,7 @@ Specify custom dimensions when building:
 pake https://example.com --width 1200 --height 800
 ```
 
-See [CLI Usage Guide](cli-usage.md#window-options) for all window options.
+See [CLI Usage Guide](cli-usage.md#width) for all window options.
 
 ---
 

--- a/docs/faq_CN.md
+++ b/docs/faq_CN.md
@@ -436,7 +436,7 @@ EOF
 pake https://example.com --width 1200 --height 800
 ```
 
-查看 [CLI 使用指南](cli-usage_CN.md#窗口选项) 了解所有窗口选项。
+查看 [CLI 使用指南](cli-usage_CN.md#width) 了解所有窗口选项。
 
 ---
 


### PR DESCRIPTION
Closes #1282

### What

The "all window options" link in the FAQ pointed to anchors that don't exist:

- `docs/faq.md` → `cli-usage.md#window-options`
- `docs/faq_CN.md` → `cli-usage_CN.md#窗口选项`

Neither `cli-usage.md` nor `cli-usage_CN.md` has a `window-options` / `窗口选项` heading, so both links currently land at the top of the page.

### Change

Repoint both links to the existing `#width` section (generated from the `#### [width]` heading present in both files) — the relevant window-sizing option for the "App Window is Too Small/Large" entry.

### Verify

```bash
grep -rn '#window-options\|#窗口选项' docs/   # no broken anchor remains
grep -n '^#### \[width\]' docs/cli-usage.md docs/cli-usage_CN.md  # target exists
```

Docs-only; `pnpm run format:check` is clean.
