### PR TITLE
fix: add missing comma in injected ad-hiding CSS selector list

### DIFF
--- a/src-tauri/src/inject/style.js
+++ b/src-tauri/src/inject/style.js
@@ -10,7 +10,7 @@ window.addEventListener("DOMContentLoaded", (_event) => {
     #Bottom > div.content > div.inner,
     #Rightbar .sep20:nth-of-type(5),
     #Rightbar > div.box:nth-child(4),
-    #Main > div.box:nth-child(8) > div
+    #Main > div.box:nth-child(8) > div,
     #Wrapper > div.sep20,
     #Main > div.box:nth-child(8),
     #masthead-ad,


### PR DESCRIPTION
Closes #1284

### What

A selector in the injected ad-hiding CSS (`src-tauri/src/inject/style.js`) was missing its trailing comma:

```js
#Main > div.box:nth-child(8) > div   // missing comma
#Wrapper > div.sep20,
```

So the two lines parsed as one descendant selector `#Main > div.box:nth-child(8) > div #Wrapper > div.sep20`. Because `#Main` and `#Wrapper` are sibling containers on V2EX, that selector matches nothing, leaving both the intended element and the `#Wrapper > div.sep20` ad separator visible.

### Change

Add the missing comma so each selector is applied independently. One-line fix; every other entry in the list already ends with a comma.

### Verify

```bash
sed -n '13,14p' src-tauri/src/inject/style.js
```

`pnpm run format:check` is clean; the unit/integration suite still passes (205).
