### PR TITLE
fix: stop warning about invalid Linux target on every default build

### DIFF
--- a/bin/helpers/merge.ts
+++ b/bin/helpers/merge.ts
@@ -17,7 +17,7 @@ import {
   WindowConfig,
 } from '@/types';
 import { tauriConfigDirectory, npmDirectory } from '@/utils/dir';
-import { LINUX_TARGET_TYPES } from '@/utils/targets';
+import { LINUX_TARGET_TYPES, resolveLinuxBundleTargets } from '@/utils/targets';
 
 /**
  * Pure transform from CLI options to the window-config slice that gets
@@ -190,20 +190,20 @@ Terminal=false
     [desktopInstallPath]: `assets/${desktopFileName}`,
   };
 
-  const validTargets = [
-    ...LINUX_TARGET_TYPES,
-    ...LINUX_TARGET_TYPES.map((target) => `${target}-arm64`),
-  ];
-  const baseTarget = options.targets.includes('-arm64')
-    ? options.targets.replace('-arm64', '')
-    : options.targets;
+  // options.targets reaches here already stripped of any -arm64 suffix by the
+  // LinuxBuilder constructor, and may carry several comma-separated formats
+  // (e.g. the distro-aware default "deb,appimage"). Validate the parsed list
+  // rather than string-matching the whole value, so a valid multi-target
+  // default no longer trips the "must be one of ..." warning on every build.
+  const { bundleTargets, hasValidTarget } = resolveLinuxBundleTargets(
+    options.targets,
+  );
 
-  if (validTargets.includes(options.targets)) {
-    // zst is repacked from the deb payload, so Tauri itself bundles a deb.
-    tauriConf.bundle.targets = [baseTarget === 'zst' ? 'deb' : baseTarget];
+  if (hasValidTarget) {
+    tauriConf.bundle.targets = bundleTargets;
   } else {
     logger.warn(
-      `✼ The target must be one of ${validTargets.join(', ')}, the default 'deb' will be used.`,
+      `✼ The target must be one of ${LINUX_TARGET_TYPES.join(', ')}, the default 'deb' will be used.`,
     );
   }
 }

--- a/bin/utils/targets.ts
+++ b/bin/utils/targets.ts
@@ -10,3 +10,19 @@ export function filterLinuxTargets(targets: string): string[] {
 export function needsTemporaryDebForZst(targets: string[]): boolean {
   return targets.includes('zst') && !targets.includes('deb');
 }
+
+// Resolves the Tauri `bundle.targets` list for a Linux build from a
+// comma-separated --targets string (e.g. the distro-aware default
+// "deb,appimage"). zst is repacked from the deb payload, so it maps to a deb
+// bundle. hasValidTarget is false only when no known target is present, which
+// is the single case that should warn and fall back to the default.
+export function resolveLinuxBundleTargets(targets: string): {
+  bundleTargets: string[];
+  hasValidTarget: boolean;
+} {
+  const requested = filterLinuxTargets(targets);
+  const bundleTargets = [
+    ...new Set(requested.map((target) => (target === 'zst' ? 'deb' : target))),
+  ];
+  return { bundleTargets, hasValidTarget: requested.length > 0 };
+}

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -508,6 +508,18 @@ function filterLinuxTargets(targets) {
 function needsTemporaryDebForZst(targets) {
     return targets.includes('zst') && !targets.includes('deb');
 }
+// Resolves the Tauri `bundle.targets` list for a Linux build from a
+// comma-separated --targets string (e.g. the distro-aware default
+// "deb,appimage"). zst is repacked from the deb payload, so it maps to a deb
+// bundle. hasValidTarget is false only when no known target is present, which
+// is the single case that should warn and fall back to the default.
+function resolveLinuxBundleTargets(targets) {
+    const requested = filterLinuxTargets(targets);
+    const bundleTargets = [
+        ...new Set(requested.map((target) => (target === 'zst' ? 'deb' : target))),
+    ];
+    return { bundleTargets, hasValidTarget: requested.length > 0 };
+}
 
 /**
  * Pure transform from CLI options to the window-config slice that gets
@@ -634,19 +646,17 @@ Terminal=false
     linuxBundle.rpm.files = {
         [desktopInstallPath]: `assets/${desktopFileName}`,
     };
-    const validTargets = [
-        ...LINUX_TARGET_TYPES,
-        ...LINUX_TARGET_TYPES.map((target) => `${target}-arm64`),
-    ];
-    const baseTarget = options.targets.includes('-arm64')
-        ? options.targets.replace('-arm64', '')
-        : options.targets;
-    if (validTargets.includes(options.targets)) {
-        // zst is repacked from the deb payload, so Tauri itself bundles a deb.
-        tauriConf.bundle.targets = [baseTarget === 'zst' ? 'deb' : baseTarget];
+    // options.targets reaches here already stripped of any -arm64 suffix by the
+    // LinuxBuilder constructor, and may carry several comma-separated formats
+    // (e.g. the distro-aware default "deb,appimage"). Validate the parsed list
+    // rather than string-matching the whole value, so a valid multi-target
+    // default no longer trips the "must be one of ..." warning on every build.
+    const { bundleTargets, hasValidTarget } = resolveLinuxBundleTargets(options.targets);
+    if (hasValidTarget) {
+        tauriConf.bundle.targets = bundleTargets;
     }
     else {
-        logger.warn(`✼ The target must be one of ${validTargets.join(', ')}, the default 'deb' will be used.`);
+        logger.warn(`✼ The target must be one of ${LINUX_TARGET_TYPES.join(', ')}, the default 'deb' will be used.`);
     }
 }
 async function mergeIcons(options, name, tauriConf, platform, safeAppName) {

--- a/tests/unit/builders.test.ts
+++ b/tests/unit/builders.test.ts
@@ -3,6 +3,7 @@ import {
   LINUX_TARGET_TYPES,
   filterLinuxTargets,
   needsTemporaryDebForZst,
+  resolveLinuxBundleTargets,
 } from '../../bin/utils/targets.js';
 
 describe('Linux target filtering', () => {
@@ -64,5 +65,42 @@ describe('Linux target filtering', () => {
     expect(needsTemporaryDebForZst(['appimage', 'zst'])).toBe(true);
     expect(needsTemporaryDebForZst(['deb', 'zst'])).toBe(false);
     expect(needsTemporaryDebForZst(['deb', 'appimage'])).toBe(false);
+  });
+});
+
+describe('resolveLinuxBundleTargets', () => {
+  it('treats the default multi-target value as valid (no fallback warning)', () => {
+    expect(resolveLinuxBundleTargets('deb,appimage')).toEqual({
+      bundleTargets: ['deb', 'appimage'],
+      hasValidTarget: true,
+    });
+  });
+
+  it('treats the RPM-distro default as valid (canonical target order)', () => {
+    expect(resolveLinuxBundleTargets('rpm,appimage')).toEqual({
+      bundleTargets: ['appimage', 'rpm'],
+      hasValidTarget: true,
+    });
+  });
+
+  it('maps zst to a deb bundle (zst is repacked from the deb payload)', () => {
+    expect(resolveLinuxBundleTargets('zst')).toEqual({
+      bundleTargets: ['deb'],
+      hasValidTarget: true,
+    });
+  });
+
+  it('deduplicates when zst and deb are both requested', () => {
+    expect(resolveLinuxBundleTargets('deb,zst')).toEqual({
+      bundleTargets: ['deb'],
+      hasValidTarget: true,
+    });
+  });
+
+  it('reports no valid target when nothing matches', () => {
+    expect(resolveLinuxBundleTargets('invalid')).toEqual({
+      bundleTargets: [],
+      hasValidTarget: false,
+    });
   });
 });


### PR DESCRIPTION
Closes #1286

### What

`mergeLinuxConfig` checked whether the entire comma-separated `options.targets` string was a single allow-list member. The distro-aware default is multi-valued (`deb,appimage` / `rpm,appimage`), so the check always failed and every default Linux build printed `✼ The target must be one of ..., the default 'deb' will be used` — while leaving `bundle.targets` untouched.

### Change

- **`bin/utils/targets.ts`** — add a pure `resolveLinuxBundleTargets(targets)` helper that parses the list via the already-tested `filterLinuxTargets`, maps `zst` → `deb` (zst is repacked from the deb payload), dedupes, and reports `hasValidTarget`. Mirrors the repo's existing "exported for testing" pattern (`buildWindowConfigOverrides`).
- **`bin/helpers/merge.ts`** — use the helper; warn only when no known target is present.
- **`tests/unit/builders.test.ts`** — unit tests for the helper (default multi-target, RPM default, zst→deb mapping, dedupe, no-valid-target).
- **`dist/cli.js`** — rebuilt.

### No build-output change

Actual built formats are driven by the `LinuxBuilder` per-target `--bundles` loop, not by `bundle.targets`. The Debian default resolves to `['deb','appimage']`, which already matches `src-tauri/tauri.linux.conf.json`. On RPM distros it now correctly resolves to the rpm/appimage set instead of leaving the deb default.

### Verify

```bash
npx vitest run tests/unit/builders.test.ts
```

Full suite: 210 passed; `pnpm run format:check` clean.
