### PR TITLE
docs: add missing Wayland AppImage entry to FAQ table of contents

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,6 +12,7 @@ Common issues and solutions when using Pake.
   - [Linux: Installing on Fedora / RHEL / Oracle Linux (RPM-based distros)](#linux-installing-on-fedora--rhel--oracle-linux-rpm-based-distros)
   - [Linux: AppImage Build Fails with "failed to run linuxdeploy"](#linux-appimage-build-fails-with-failed-to-run-linuxdeploy)
   - [Linux: AppImage Crashes at Launch with WebKitNetworkProcess Not Found](#linux-appimage-crashes-at-launch-with-webkitnetworkprocess-not-found)
+  - [Linux: AppImage Opens but Buttons or Keyboard Do Not Work on Wayland](#linux-appimage-opens-but-buttons-or-keyboard-do-not-work-on-wayland)
   - [Linux: "cargo: command not found" After Installing Rust](#linux-cargo-command-not-found-after-installing-rust)
   - [Windows: Installation Timeout During First Build](#windows-installation-timeout-during-first-build)
   - [Windows: Missing Visual Studio Build Tools](#windows-missing-visual-studio-build-tools)

--- a/docs/faq_CN.md
+++ b/docs/faq_CN.md
@@ -12,6 +12,7 @@
   - [Linux：在 Fedora / RHEL / Oracle Linux 等 RPM 系发行版上安装](#linux在-fedora--rhel--oracle-linux-等-rpm-系发行版上安装)
   - [Linux：AppImage 构建失败，提示 "failed to run linuxdeploy"](#linuxappimage-构建失败提示-failed-to-run-linuxdeploy)
   - [Linux：AppImage 启动即崩溃，提示找不到 WebKitNetworkProcess](#linuxappimage-启动即崩溃提示找不到-webkitnetworkprocess)
+  - [Linux：AppImage 打开后按钮或键盘在 Wayland 下不可用](#linuxappimage-打开后按钮或键盘在-wayland-下不可用)
   - [Linux:"cargo: command not found" 即使已安装 Rust](#linuxcargo-command-not-found-即使已安装-rust)
   - [Windows：首次构建时安装超时](#windows首次构建时安装超时)
   - [Windows：缺少 Visual Studio 构建工具](#windows缺少-visual-studio-构建工具)


### PR DESCRIPTION
Closes #1288

### What

The FAQ section "Linux: AppImage Opens but Buttons or Keyboard Do Not Work on Wayland" exists in the body of both `docs/faq.md` and `docs/faq_CN.md` but was missing from each file's Build Issues table of contents.

### Change

Add the TOC entry in both languages with the correct GitHub heading anchors (`#linux-appimage-opens-but-buttons-or-keyboard-do-not-work-on-wayland` and the Simplified Chinese equivalent). The anchors were verified by reproducing GitHub's slug algorithm against the existing TOC entries.

Docs-only; `pnpm run format:check` is clean.