### PR TITLE
refactor: drop unreachable arm64 branch in LinuxBuilder.getFileName

### DIFF
--- a/bin/builders/LinuxBuilder.ts
+++ b/bin/builders/LinuxBuilder.ts
@@ -42,18 +42,10 @@ export default class LinuxBuilder extends BaseBuilder {
     if (this.buildArch === 'arm64') {
       arch =
         buildType === 'rpm' || buildType === 'appimage' ? 'aarch64' : 'arm64';
+    } else if (this.buildArch === 'x64') {
+      arch = buildType === 'rpm' ? 'x86_64' : 'amd64';
     } else {
-      if (this.buildArch === 'x64') {
-        arch = buildType === 'rpm' ? 'x86_64' : 'amd64';
-      } else {
-        arch = this.buildArch;
-        if (
-          this.buildArch === 'arm64' &&
-          (buildType === 'rpm' || buildType === 'appimage')
-        ) {
-          arch = 'aarch64';
-        }
-      }
+      arch = this.buildArch;
     }
 
     if (this.currentBuildType === 'rpm') {

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -1518,17 +1518,11 @@ class LinuxBuilder extends BaseBuilder {
             arch =
                 buildType === 'rpm' || buildType === 'appimage' ? 'aarch64' : 'arm64';
         }
+        else if (this.buildArch === 'x64') {
+            arch = buildType === 'rpm' ? 'x86_64' : 'amd64';
+        }
         else {
-            if (this.buildArch === 'x64') {
-                arch = buildType === 'rpm' ? 'x86_64' : 'amd64';
-            }
-            else {
-                arch = this.buildArch;
-                if (this.buildArch === 'arm64' &&
-                    (buildType === 'rpm' || buildType === 'appimage')) {
-                    arch = 'aarch64';
-                }
-            }
+            arch = this.buildArch;
         }
         if (this.currentBuildType === 'rpm') {
             return `${name}-${version}-1.${arch}`;


### PR DESCRIPTION
Closes #1290

### What

The inner `if (this.buildArch === 'arm64' && ...)` in `getFileName()` sits inside the `else` of `if (this.buildArch === 'arm64')`, so `this.buildArch` is provably never `'arm64'` there — the branch and its `aarch64` assignment are unreachable. The arm64 → aarch64 mapping is already handled by the first branch.

### Change

Remove the dead branch and flatten the nested `else { if }` into an `else if` chain. `dist/cli.js` rebuilt.

### Verify

Behavior-preserving; full suite passes:

```bash
npx vitest run
```

205 passed; `pnpm run format:check` clean.