### PR TITLE
test: add unit coverage for bin/utils/error.ts

### DIFF
--- a/tests/unit/error.test.ts
+++ b/tests/unit/error.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { PakeError, isPakeError } from '@/utils/error';
+
+describe('PakeError', () => {
+  it('is an Error flagged as a user error with the right name', () => {
+    const err = new PakeError('boom');
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.isUserError).toBe(true);
+    expect(err.name).toBe('PakeError');
+    expect(err.message).toBe('boom');
+  });
+});
+
+describe('isPakeError', () => {
+  it('returns true for a PakeError instance', () => {
+    expect(isPakeError(new PakeError('x'))).toBe(true);
+  });
+
+  it('returns true for a duck-typed object with isUserError === true', () => {
+    // Cross-module instances may fail instanceof, so the flag is also accepted.
+    expect(isPakeError({ isUserError: true })).toBe(true);
+  });
+
+  it('returns false for a plain Error', () => {
+    expect(isPakeError(new Error('x'))).toBe(false);
+  });
+
+  it('returns false for an object whose isUserError is not strictly true', () => {
+    expect(isPakeError({ isUserError: false })).toBe(false);
+    expect(isPakeError({})).toBe(false);
+  });
+
+  it('returns false for null and undefined (typeof null === "object" guard)', () => {
+    expect(isPakeError(null)).toBe(false);
+    expect(isPakeError(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1292

### What

Adds `tests/unit/error.test.ts` for the previously untested `PakeError` / `isPakeError` helpers.

### Coverage

- `PakeError`: `instanceof Error`, `isUserError === true`, `name === 'PakeError'`, message passthrough.
- `isPakeError`: PakeError instance → true; duck-typed `{ isUserError: true }` → true; plain `Error` → false; `{ isUserError: false }` / `{}` → false; `null` / `undefined` → false (the `typeof null === 'object'` guard).

Tests only — no `bin/` change, no `dist/cli.js` rebuild.

### Verify

```bash
npx vitest run tests/unit/error.test.ts
```

6 new tests; full suite 211 passed; `pnpm run format:check` clean.