### PR TITLE
test: cover validateUrlInput in bin/utils/validate.ts

### DIFF
--- a/tests/unit/validate-url-input.test.ts
+++ b/tests/unit/validate-url-input.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { InvalidArgumentError } from 'commander';
+import { validateUrlInput } from '@/utils/validate';
+
+describe('validateUrlInput', () => {
+  it('prepends https:// to a bare domain', () => {
+    expect(validateUrlInput('github.com')).toBe('https://github.com');
+  });
+
+  it('passes a fully-qualified URL through unchanged', () => {
+    expect(validateUrlInput('https://example.com/path')).toBe(
+      'https://example.com/path',
+    );
+  });
+
+  it('returns an existing local path untouched', () => {
+    // A path that exists on disk (file or directory) is returned untouched,
+    // not normalized as a URL.
+    const cwd = process.cwd();
+    expect(validateUrlInput(cwd)).toBe(cwd);
+  });
+
+  it('wraps a normalize failure in InvalidArgumentError', () => {
+    // '' is not a file, normalizeUrl('') -> 'https://' -> new URL() throws.
+    expect(() => validateUrlInput('')).toThrow(InvalidArgumentError);
+  });
+});


### PR DESCRIPTION
Closes #1294

### What

Adds `tests/unit/validate-url-input.test.ts` for the previously untested `validateUrlInput` coercer used by the CLI `[url]` argument.

### Coverage

- bare domain → `https://` prepended;
- fully-qualified URL → unchanged;
- existing local path → returned untouched (local-file branch);
- normalize failure → re-thrown as commander `InvalidArgumentError`.

Tests only — no `bin/` change, no `dist/cli.js` rebuild.

### Verify

```bash
npx vitest run tests/unit/validate-url-input.test.ts
```

`pnpm run format:check` clean.