### PR TITLE
fix: drop removed 'npm bin' call from the GitHub Action setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,9 +56,6 @@ runs:
           npm run cli:build
         fi
 
-        # Ensure node is accessible in subsequent steps
-        echo "$(npm bin)" >> $GITHUB_PATH
-
         # Install Rust/Cargo if needed
         if ! command -v cargo &> /dev/null; then
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
Closes #1296

### What

The action's Setup step ran `echo "$(npm bin)" >> $GITHUB_PATH`. `npm bin` was removed in npm v9 (2022); GitHub runners ship npm 10+, so it errors with `Unknown command: bin`, `$(npm bin)` is empty, and the step appends an empty entry to `$GITHUB_PATH` on every run.

### Why removal is safe

node is already on PATH (the step just ran `npm install`/`npm run cli:build`), and the Build step calls `node dist/cli.js` directly — nothing depends on `node_modules/.bin` being on PATH.

### Verify

```bash
npm bin    # Unknown command: "bin"  (npm >= 9)
```

YAML still parses; `pnpm run format:check` clean.