### PR TITLE
docs: fix Tauri v2 examples in advanced-usage (invoke API + pake.json schema)

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -83,7 +83,7 @@ Send messages between web content and Pake container.
 **Web Side (JavaScript):**
 
 ```javascript
-window.__TAURI__.invoke("handle_scroll", {
+window.__TAURI__.core.invoke("handle_scroll", {
   scrollY: window.scrollY,
   scrollX: window.scrollX,
 });
@@ -104,17 +104,19 @@ Configure window properties in `pake.json`:
 
 ```json
 {
-  "windows": {
-    "width": 1200,
-    "height": 780,
-    "fullscreen": false,
-    "resizable": true
-  },
-  "hideTitleBar": true
+  "windows": [
+    {
+      "width": 1200,
+      "height": 780,
+      "fullscreen": false,
+      "resizable": true,
+      "hide_title_bar": true
+    }
+  ]
 }
 ```
 
-`hideTitleBar` is only supported on macOS. It is ignored on Windows and Linux.
+`hide_title_bar` is the `pake.json` key (the CLI exposes it as `--hide-title-bar`). It is only supported on macOS and is ignored on Windows and Linux.
 
 ## Static File Packaging
 

--- a/docs/advanced-usage_CN.md
+++ b/docs/advanced-usage_CN.md
@@ -83,7 +83,7 @@ if (window.Notification && Notification.permission === "default") {
 **网页端（JavaScript）：**
 
 ```javascript
-window.__TAURI__.invoke("handle_scroll", {
+window.__TAURI__.core.invoke("handle_scroll", {
   scrollY: window.scrollY,
   scrollX: window.scrollX,
 });
@@ -104,17 +104,19 @@ fn handle_scroll(scroll_y: f64, scroll_x: f64) {
 
 ```json
 {
-  "windows": {
-    "width": 1200,
-    "height": 780,
-    "fullscreen": false,
-    "resizable": true
-  },
-  "hideTitleBar": true
+  "windows": [
+    {
+      "width": 1200,
+      "height": 780,
+      "fullscreen": false,
+      "resizable": true,
+      "hide_title_bar": true
+    }
+  ]
 }
 ```
 
-`hideTitleBar` 仅支持 macOS，在 Windows 和 Linux 上会被忽略。
+`hide_title_bar` 是 `pake.json` 中的字段名（CLI 对应参数为 `--hide-title-bar`）。仅支持 macOS，在 Windows 和 Linux 上会被忽略。
 
 ## 静态文件打包
 


### PR DESCRIPTION
Closes #1298

### What

Two copy-breaking examples in `docs/advanced-usage.md` and `docs/advanced-usage_CN.md`:

1. **Container Communication** used the Tauri v1 global `window.__TAURI__.invoke`. Pake runs Tauri v2 with `withGlobalTauri`, where invoke is `window.__TAURI__.core.invoke` (matching Pake's own injected scripts). The v1 path throws at runtime → fixed.
2. **Window Configuration** showed `windows` as an object with a top-level camelCase `hideTitleBar`. The real `pake.json` uses a `windows` **array** (indexed `windows[0]` in `merge.ts`) with the snake_case key `hide_title_bar` nested per window → fixed, and the prose now names the correct key.

### Verify

```bash
grep -n 'core.invoke' docs/advanced-usage.md docs/advanced-usage_CN.md
# JSON example now mirrors src-tauri/pake.json (windows array + hide_title_bar)
```

Both example JSON blocks parse and `windows` is an array; `pnpm run format:check` clean. Docs-only.