### PR TITLE
fix: derive a valid file extension from data:image download URIs

### DIFF
--- a/src-tauri/src/inject/event.js
+++ b/src-tauri/src/inject/event.js
@@ -1124,8 +1124,17 @@ function getFilenameFromUrl(url) {
 
       // Detect image type from URL or data URI
       if (url.startsWith("data:image/")) {
-        const mimeType = url.substring(11, url.indexOf(";"));
-        filename = `image-${timestamp}.${mimeType}`;
+        // Read only the MIME subtype: stop at ';' (params) or ',' (data),
+        // whichever comes first, so we never fold the encoding/payload into
+        // the extension. Map structured suffixes (svg+xml -> svg) and jpeg.
+        const semicolon = url.indexOf(";");
+        const comma = url.indexOf(",");
+        let end = url.length;
+        if (semicolon !== -1) end = Math.min(end, semicolon);
+        if (comma !== -1) end = Math.min(end, comma);
+        let ext = url.substring(11, end).split("+")[0];
+        if (ext === "jpeg") ext = "jpg";
+        filename = `image-${timestamp}.${ext}`;
       } else {
         // Default to common image extensions based on common patterns
         if (url.includes("jpg") || url.includes("jpeg")) {

--- a/tests/unit/event-link-guard.test.js
+++ b/tests/unit/event-link-guard.test.js
@@ -282,3 +282,28 @@ describe("event link guard", () => {
     ]);
   });
 });
+
+describe("getFilenameFromUrl data URI extension", () => {
+  it("maps a structured image subtype to a real extension (svg+xml -> svg)", () => {
+    const context = loadEventHelpers();
+    const filename = context.getFilenameFromUrl(
+      "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=",
+    );
+    expect(filename).toMatch(/^image-.*\.svg$/);
+    expect(filename).not.toContain("+");
+  });
+
+  it("normalizes jpeg to jpg", () => {
+    const context = loadEventHelpers();
+    expect(context.getFilenameFromUrl("data:image/jpeg;base64,AAAA")).toMatch(
+      /^image-.*\.jpg$/,
+    );
+  });
+
+  it("does not fold the data payload into the extension when ';' is absent", () => {
+    const context = loadEventHelpers();
+    const filename = context.getFilenameFromUrl("data:image/png,rawdata");
+    expect(filename).toMatch(/^image-.*\.png$/);
+    expect(filename).not.toContain("data:image/");
+  });
+});


### PR DESCRIPTION
Closes #1300

### What

`getFilenameFromUrl` built the download extension from `url.substring(11, url.indexOf(';'))`. For `data:image/svg+xml;base64,...` that produced the invalid `.svg+xml`, and for a data URI without a `;` it produced `.data:image/` (because `substring(11, -1)` collapses).

### Change

- **`src-tauri/src/inject/event.js`** — read the MIME subtype only up to the first `;` or `,`, strip structured `+xml`-style suffixes (`svg+xml` → `svg`), and map `jpeg` → `jpg`.
- **`tests/unit/event-link-guard.test.js`** — regression tests for `svg+xml`, `jpeg`, and the no-`;` case.

`event.js` is injected runtime JS (not bundled into `dist/cli.js`), so no CLI rebuild.

### Verify

```bash
npx vitest run tests/unit/event-link-guard.test.js
```

The 3 new tests fail on `main` and pass with this change (verified by reverting just `event.js`). Full suite: 208 passed; `pnpm run format:check` clean.