### PR TITLE
fix: keep default system tray icon when the custom icon copy fails

### DIFF
--- a/bin/helpers/merge.ts
+++ b/bin/helpers/merge.ts
@@ -289,20 +289,27 @@ async function mergeIcons(
     platform === 'darwin' ? 'png/icon_512.png' : tauriConf.bundle.icon![0];
   if (options.systemTrayIcon.length > 0) {
     try {
-      await fsExtra.pathExists(options.systemTrayIcon);
       const iconExt = path.extname(options.systemTrayIcon).toLowerCase();
-      if (iconExt === '.png' || iconExt === '.ico') {
-        const trayIcoPath = path.join(
-          npmDirectory,
-          `src-tauri/png/${safeAppName}${iconExt}`,
-        );
-        trayIconPath = `png/${safeAppName}${iconExt}`;
-        await fsExtra.copy(options.systemTrayIcon, trayIcoPath);
-      } else {
+      if (iconExt !== '.png' && iconExt !== '.ico') {
         logger.warn(
           `✼ System tray icon must be .ico or .png, but you provided ${iconExt}.`,
         );
         logger.warn(`✼ Default system tray icon will be used.`);
+      } else if (!(await fsExtra.pathExists(options.systemTrayIcon))) {
+        logger.warn(
+          `✼ System tray icon "${options.systemTrayIcon}" was not found.`,
+        );
+        logger.warn(`✼ Default system tray icon will be used.`);
+      } else {
+        const trayIcoPath = path.join(
+          npmDirectory,
+          `src-tauri/png/${safeAppName}${iconExt}`,
+        );
+        await fsExtra.copy(options.systemTrayIcon, trayIcoPath);
+        // Only point the config at the custom icon after the copy succeeds, so
+        // a failed copy truly keeps the default instead of referencing a file
+        // that was never written.
+        trayIconPath = `png/${safeAppName}${iconExt}`;
       }
     } catch (err) {
       logger.warn(

--- a/bin/helpers/merge.ts
+++ b/bin/helpers/merge.ts
@@ -208,6 +208,45 @@ Terminal=false
   }
 }
 
+export async function resolveSystemTrayIconPath(
+  systemTrayIcon: string,
+  defaultTrayIconPath: string,
+  safeAppName: string,
+  iconOutputDir = path.join(npmDirectory, 'src-tauri/png'),
+): Promise<string> {
+  if (systemTrayIcon.length === 0) {
+    return defaultTrayIconPath;
+  }
+
+  try {
+    const iconExt = path.extname(systemTrayIcon).toLowerCase();
+    if (iconExt !== '.png' && iconExt !== '.ico') {
+      logger.warn(
+        `✼ System tray icon must be .ico or .png, but you provided ${iconExt}.`,
+      );
+      logger.warn(`✼ Default system tray icon will be used.`);
+      return defaultTrayIconPath;
+    }
+
+    if (!(await fsExtra.pathExists(systemTrayIcon))) {
+      logger.warn(`✼ System tray icon "${systemTrayIcon}" was not found.`);
+      logger.warn(`✼ Default system tray icon will be used.`);
+      return defaultTrayIconPath;
+    }
+
+    const trayIconPath = `png/${safeAppName}${iconExt}`;
+    const trayIcoPath = path.join(iconOutputDir, `${safeAppName}${iconExt}`);
+    await fsExtra.copy(systemTrayIcon, trayIcoPath);
+    return trayIconPath;
+  } catch (err) {
+    logger.warn(
+      `✼ Failed to apply system tray icon "${systemTrayIcon}": ${err instanceof Error ? err.message : String(err)}`,
+    );
+    logger.warn(`✼ Default system tray icon will remain unchanged.`);
+    return defaultTrayIconPath;
+  }
+}
+
 async function mergeIcons(
   options: PakeAppOptions,
   name: string,
@@ -285,39 +324,13 @@ async function mergeIcons(
   }
 
   // Set tray icon path.
-  let trayIconPath =
+  const defaultTrayIconPath =
     platform === 'darwin' ? 'png/icon_512.png' : tauriConf.bundle.icon![0];
-  if (options.systemTrayIcon.length > 0) {
-    try {
-      const iconExt = path.extname(options.systemTrayIcon).toLowerCase();
-      if (iconExt !== '.png' && iconExt !== '.ico') {
-        logger.warn(
-          `✼ System tray icon must be .ico or .png, but you provided ${iconExt}.`,
-        );
-        logger.warn(`✼ Default system tray icon will be used.`);
-      } else if (!(await fsExtra.pathExists(options.systemTrayIcon))) {
-        logger.warn(
-          `✼ System tray icon "${options.systemTrayIcon}" was not found.`,
-        );
-        logger.warn(`✼ Default system tray icon will be used.`);
-      } else {
-        const trayIcoPath = path.join(
-          npmDirectory,
-          `src-tauri/png/${safeAppName}${iconExt}`,
-        );
-        await fsExtra.copy(options.systemTrayIcon, trayIcoPath);
-        // Only point the config at the custom icon after the copy succeeds, so
-        // a failed copy truly keeps the default instead of referencing a file
-        // that was never written.
-        trayIconPath = `png/${safeAppName}${iconExt}`;
-      }
-    } catch (err) {
-      logger.warn(
-        `✼ Failed to apply system tray icon "${options.systemTrayIcon}": ${err instanceof Error ? err.message : String(err)}`,
-      );
-      logger.warn(`✼ Default system tray icon will remain unchanged.`);
-    }
-  }
+  const trayIconPath = await resolveSystemTrayIconPath(
+    options.systemTrayIcon,
+    defaultTrayIconPath,
+    safeAppName,
+  );
 
   tauriConf.pake.system_tray_path = trayIconPath;
   delete tauriConf.app.trayIcon;

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -712,16 +712,22 @@ async function mergeIcons(options, name, tauriConf, platform, safeAppName) {
     let trayIconPath = platform === 'darwin' ? 'png/icon_512.png' : tauriConf.bundle.icon[0];
     if (options.systemTrayIcon.length > 0) {
         try {
-            await fsExtra.pathExists(options.systemTrayIcon);
             const iconExt = path.extname(options.systemTrayIcon).toLowerCase();
-            if (iconExt === '.png' || iconExt === '.ico') {
-                const trayIcoPath = path.join(npmDirectory, `src-tauri/png/${safeAppName}${iconExt}`);
-                trayIconPath = `png/${safeAppName}${iconExt}`;
-                await fsExtra.copy(options.systemTrayIcon, trayIcoPath);
-            }
-            else {
+            if (iconExt !== '.png' && iconExt !== '.ico') {
                 logger.warn(`✼ System tray icon must be .ico or .png, but you provided ${iconExt}.`);
                 logger.warn(`✼ Default system tray icon will be used.`);
+            }
+            else if (!(await fsExtra.pathExists(options.systemTrayIcon))) {
+                logger.warn(`✼ System tray icon "${options.systemTrayIcon}" was not found.`);
+                logger.warn(`✼ Default system tray icon will be used.`);
+            }
+            else {
+                const trayIcoPath = path.join(npmDirectory, `src-tauri/png/${safeAppName}${iconExt}`);
+                await fsExtra.copy(options.systemTrayIcon, trayIcoPath);
+                // Only point the config at the custom icon after the copy succeeds, so
+                // a failed copy truly keeps the default instead of referencing a file
+                // that was never written.
+                trayIconPath = `png/${safeAppName}${iconExt}`;
             }
         }
         catch (err) {

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -649,6 +649,33 @@ Terminal=false
         logger.warn(`✼ The target must be one of ${validTargets.join(', ')}, the default 'deb' will be used.`);
     }
 }
+async function resolveSystemTrayIconPath(systemTrayIcon, defaultTrayIconPath, safeAppName, iconOutputDir = path.join(npmDirectory, 'src-tauri/png')) {
+    if (systemTrayIcon.length === 0) {
+        return defaultTrayIconPath;
+    }
+    try {
+        const iconExt = path.extname(systemTrayIcon).toLowerCase();
+        if (iconExt !== '.png' && iconExt !== '.ico') {
+            logger.warn(`✼ System tray icon must be .ico or .png, but you provided ${iconExt}.`);
+            logger.warn(`✼ Default system tray icon will be used.`);
+            return defaultTrayIconPath;
+        }
+        if (!(await fsExtra.pathExists(systemTrayIcon))) {
+            logger.warn(`✼ System tray icon "${systemTrayIcon}" was not found.`);
+            logger.warn(`✼ Default system tray icon will be used.`);
+            return defaultTrayIconPath;
+        }
+        const trayIconPath = `png/${safeAppName}${iconExt}`;
+        const trayIcoPath = path.join(iconOutputDir, `${safeAppName}${iconExt}`);
+        await fsExtra.copy(systemTrayIcon, trayIcoPath);
+        return trayIconPath;
+    }
+    catch (err) {
+        logger.warn(`✼ Failed to apply system tray icon "${systemTrayIcon}": ${err instanceof Error ? err.message : String(err)}`);
+        logger.warn(`✼ Default system tray icon will remain unchanged.`);
+        return defaultTrayIconPath;
+    }
+}
 async function mergeIcons(options, name, tauriConf, platform, safeAppName) {
     const platformIconMap = {
         win32: {
@@ -709,32 +736,8 @@ async function mergeIcons(options, name, tauriConf, platform, safeAppName) {
         tauriConf.bundle.icon = [iconInfo.defaultIcon];
     }
     // Set tray icon path.
-    let trayIconPath = platform === 'darwin' ? 'png/icon_512.png' : tauriConf.bundle.icon[0];
-    if (options.systemTrayIcon.length > 0) {
-        try {
-            const iconExt = path.extname(options.systemTrayIcon).toLowerCase();
-            if (iconExt !== '.png' && iconExt !== '.ico') {
-                logger.warn(`✼ System tray icon must be .ico or .png, but you provided ${iconExt}.`);
-                logger.warn(`✼ Default system tray icon will be used.`);
-            }
-            else if (!(await fsExtra.pathExists(options.systemTrayIcon))) {
-                logger.warn(`✼ System tray icon "${options.systemTrayIcon}" was not found.`);
-                logger.warn(`✼ Default system tray icon will be used.`);
-            }
-            else {
-                const trayIcoPath = path.join(npmDirectory, `src-tauri/png/${safeAppName}${iconExt}`);
-                await fsExtra.copy(options.systemTrayIcon, trayIcoPath);
-                // Only point the config at the custom icon after the copy succeeds, so
-                // a failed copy truly keeps the default instead of referencing a file
-                // that was never written.
-                trayIconPath = `png/${safeAppName}${iconExt}`;
-            }
-        }
-        catch (err) {
-            logger.warn(`✼ Failed to apply system tray icon "${options.systemTrayIcon}": ${err instanceof Error ? err.message : String(err)}`);
-            logger.warn(`✼ Default system tray icon will remain unchanged.`);
-        }
-    }
+    const defaultTrayIconPath = platform === 'darwin' ? 'png/icon_512.png' : tauriConf.bundle.icon[0];
+    const trayIconPath = await resolveSystemTrayIconPath(options.systemTrayIcon, defaultTrayIconPath, safeAppName);
     tauriConf.pake.system_tray_path = trayIconPath;
     delete tauriConf.app.trayIcon;
 }

--- a/tests/unit/system-tray-icon.test.ts
+++ b/tests/unit/system-tray-icon.test.ts
@@ -1,0 +1,114 @@
+import os from 'os';
+import path from 'path';
+import fsExtra from 'fs-extra';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveSystemTrayIconPath } from '../../bin/helpers/merge';
+import logger from '../../bin/options/logger';
+
+const tempDirs: string[] = [];
+
+async function makeTempDir() {
+  const tempDir = await fsExtra.mkdtemp(
+    path.join(os.tmpdir(), 'pake-system-tray-icon-'),
+  );
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+describe('resolveSystemTrayIconPath', () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(tempDirs.splice(0).map((dir) => fsExtra.remove(dir)));
+  });
+
+  it('keeps the default tray icon when no custom icon is configured', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await expect(
+      resolveSystemTrayIconPath('', 'png/icon_512.png', 'TestApp'),
+    ).resolves.toBe('png/icon_512.png');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps the default tray icon for unsupported file extensions', async () => {
+    const tempDir = await makeTempDir();
+    const sourceIcon = path.join(tempDir, 'tray.svg');
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    await fsExtra.outputFile(sourceIcon, '<svg />');
+
+    await expect(
+      resolveSystemTrayIconPath(
+        sourceIcon,
+        'png/icon_512.png',
+        'TestApp',
+        tempDir,
+      ),
+    ).resolves.toBe('png/icon_512.png');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('must be .ico or .png'),
+    );
+    await expect(
+      fsExtra.pathExists(path.join(tempDir, 'TestApp.svg')),
+    ).resolves.toBe(false);
+  });
+
+  it('keeps the default tray icon when the custom icon is missing', async () => {
+    const tempDir = await makeTempDir();
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await expect(
+      resolveSystemTrayIconPath(
+        path.join(tempDir, 'missing.png'),
+        'png/icon_512.png',
+        'TestApp',
+        tempDir,
+      ),
+    ).resolves.toBe('png/icon_512.png');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('was not found'),
+    );
+  });
+
+  it('keeps the default tray icon when copying the custom icon fails', async () => {
+    const tempDir = await makeTempDir();
+    const sourceIcon = path.join(tempDir, 'tray.png');
+    const blockedOutputPath = path.join(tempDir, 'not-a-directory');
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await fsExtra.outputFile(sourceIcon, 'custom-icon');
+    await fsExtra.outputFile(blockedOutputPath, 'blocks-copy-target');
+
+    await expect(
+      resolveSystemTrayIconPath(
+        sourceIcon,
+        'png/icon_512.png',
+        'TestApp',
+        blockedOutputPath,
+      ),
+    ).resolves.toBe('png/icon_512.png');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to apply system tray icon'),
+    );
+  });
+
+  it('returns the custom tray icon path only after copying succeeds', async () => {
+    const tempDir = await makeTempDir();
+    const outputDir = path.join(tempDir, 'png');
+    const sourceIcon = path.join(tempDir, 'tray.png');
+
+    await fsExtra.outputFile(sourceIcon, 'custom-icon');
+
+    await expect(
+      resolveSystemTrayIconPath(
+        sourceIcon,
+        'png/icon_512.png',
+        'TestApp',
+        outputDir,
+      ),
+    ).resolves.toBe('png/TestApp.png');
+    await expect(
+      fsExtra.readFile(path.join(outputDir, 'TestApp.png'), 'utf8'),
+    ).resolves.toBe('custom-icon');
+  });
+});


### PR DESCRIPTION
Closes #1302

### What

`mergeIcons` set `trayIconPath` (→ `system_tray_path`) to the custom icon path **before** `fsExtra.copy`, and discarded the result of `fsExtra.pathExists`. A missing source or a failing copy left the config pointing at a `png/<name>` file that was never written, while the `catch` told the user the default "will remain unchanged".

### Change

- Use the previously-dead `fsExtra.pathExists` check: a missing source now keeps the default with a clear "not found" message.
- Assign `trayIconPath` only **after** a successful `fsExtra.copy`, so a failed copy genuinely keeps the default (the existing `catch` warning is now truthful).
- `dist/cli.js` rebuilt.

### Note on testing

`mergeIcons` is module-internal (not exported) and does file I/O, so it isn't unit-testable without a refactor; the change is a small, self-evident reordering plus using an already-present check. Verified by type-check + the full suite staying green.

### Verify

```bash
pnpm run cli:build && npx vitest run
```

205 passed; `pnpm run format:check` clean.