### PR TITLE
feat: enhance Linux icon handling and validation

### DIFF
--- a/bin/helpers/merge.ts
+++ b/bin/helpers/merge.ts
@@ -139,6 +139,28 @@ async function handleLocalFile(
   }
 }
 
+export function buildLinuxDesktopContent(
+  name: string,
+  title: string | undefined,
+  linuxBinaryName: string,
+): string {
+  const chineseName = title && /[\u4e00-\u9fa5]/.test(title) ? title : null;
+
+  return `[Desktop Entry]
+Version=1.0
+Type=Application
+Name=${name}
+${chineseName ? `Name[zh_CN]=${chineseName}` : ''}
+Comment=${name}
+Exec=${linuxBinaryName}
+Icon=${linuxBinaryName}
+Categories=Network;WebBrowser;Utility;
+MimeType=text/html;text/xml;application/xhtml_xml;
+StartupNotify=true
+Terminal=false
+`;
+}
+
 async function mergeLinuxConfig(
   options: PakeAppOptions,
   name: string,
@@ -155,24 +177,11 @@ async function mergeLinuxConfig(
 
   const linuxName = generateLinuxPackageName(name);
   const desktopFileName = `com.pake.${linuxName}.desktop`;
-  // Tauri installs hicolor icons using mainBinaryName, not the png filename.
-  const iconName = linuxBinaryName;
-  const { title } = options;
-
-  const chineseName = title && /[\u4e00-\u9fa5]/.test(title) ? title : null;
-  const desktopContent = `[Desktop Entry]
-Version=1.0
-Type=Application
-Name=${name}
-${chineseName ? `Name[zh_CN]=${chineseName}` : ''}
-Comment=${name}
-Exec=${linuxBinaryName}
-Icon=${iconName}
-Categories=Network;WebBrowser;Utility;
-MimeType=text/html;text/xml;application/xhtml_xml;
-StartupNotify=true
-Terminal=false
-`;
+  const desktopContent = buildLinuxDesktopContent(
+    name,
+    options.title,
+    linuxBinaryName,
+  );
 
   const srcAssetsDir = path.join(npmDirectory, 'src-tauri/assets');
   const srcDesktopFilePath = path.join(srcAssetsDir, desktopFileName);

--- a/bin/helpers/merge.ts
+++ b/bin/helpers/merge.ts
@@ -155,7 +155,8 @@ async function mergeLinuxConfig(
 
   const linuxName = generateLinuxPackageName(name);
   const desktopFileName = `com.pake.${linuxName}.desktop`;
-  const iconName = `${linuxName}_512`;
+  // Tauri installs hicolor icons using mainBinaryName, not the png filename.
+  const iconName = linuxBinaryName;
   const { title } = options;
 
   const chineseName = title && /[\u4e00-\u9fa5]/.test(title) ? title : null;

--- a/bin/options/icon.ts
+++ b/bin/options/icon.ts
@@ -282,6 +282,22 @@ async function convertIconFormat(
   }
 }
 
+async function isLinuxBundleIconReady(iconPath: string): Promise<boolean> {
+  if (!IS_LINUX || path.extname(iconPath).toLowerCase() !== '.png') {
+    return false;
+  }
+
+  try {
+    const { width, height } = await sharp(iconPath).metadata();
+    return (
+      width === PLATFORM_CONFIG.linux.size &&
+      height === PLATFORM_CONFIG.linux.size
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Processes downloaded or local icon for platform-specific format
  */
@@ -295,7 +311,7 @@ async function processIcon(
   const ext = path.extname(iconPath).toLowerCase();
   const isCorrectFormat =
     (IS_WIN && ext === '.ico') ||
-    (IS_LINUX && ext === '.png') ||
+    (IS_LINUX && (await isLinuxBundleIconReady(iconPath))) ||
     (!IS_WIN && !IS_LINUX && ext === '.icns');
 
   if (isCorrectFormat) {

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -596,6 +596,22 @@ async function handleLocalFile(url, useLocalFile, tauriConf) {
         tauriConf.pake.windows[0].url_type = 'web';
     }
 }
+function buildLinuxDesktopContent(name, title, linuxBinaryName) {
+    const chineseName = title && /[\u4e00-\u9fa5]/.test(title) ? title : null;
+    return `[Desktop Entry]
+Version=1.0
+Type=Application
+Name=${name}
+${chineseName ? `Name[zh_CN]=${chineseName}` : ''}
+Comment=${name}
+Exec=${linuxBinaryName}
+Icon=${linuxBinaryName}
+Categories=Network;WebBrowser;Utility;
+MimeType=text/html;text/xml;application/xhtml_xml;
+StartupNotify=true
+Terminal=false
+`;
+}
 async function mergeLinuxConfig(options, name, tauriConf, linuxBinaryName) {
     const linuxBundle = tauriConf.bundle.linux;
     if (!linuxBundle) {
@@ -604,23 +620,7 @@ async function mergeLinuxConfig(options, name, tauriConf, linuxBinaryName) {
     delete linuxBundle.deb.files;
     const linuxName = generateLinuxPackageName(name);
     const desktopFileName = `com.pake.${linuxName}.desktop`;
-    // Tauri installs hicolor icons using mainBinaryName, not the png filename.
-    const iconName = linuxBinaryName;
-    const { title } = options;
-    const chineseName = title && /[\u4e00-\u9fa5]/.test(title) ? title : null;
-    const desktopContent = `[Desktop Entry]
-Version=1.0
-Type=Application
-Name=${name}
-${chineseName ? `Name[zh_CN]=${chineseName}` : ''}
-Comment=${name}
-Exec=${linuxBinaryName}
-Icon=${iconName}
-Categories=Network;WebBrowser;Utility;
-MimeType=text/html;text/xml;application/xhtml_xml;
-StartupNotify=true
-Terminal=false
-`;
+    const desktopContent = buildLinuxDesktopContent(name, options.title, linuxBinaryName);
     const srcAssetsDir = path.join(npmDirectory, 'src-tauri/assets');
     const srcDesktopFilePath = path.join(srcAssetsDir, desktopFileName);
     await fsExtra.ensureDir(srcAssetsDir);

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -604,7 +604,8 @@ async function mergeLinuxConfig(options, name, tauriConf, linuxBinaryName) {
     delete linuxBundle.deb.files;
     const linuxName = generateLinuxPackageName(name);
     const desktopFileName = `com.pake.${linuxName}.desktop`;
-    const iconName = `${linuxName}_512`;
+    // Tauri installs hicolor icons using mainBinaryName, not the png filename.
+    const iconName = linuxBinaryName;
     const { title } = options;
     const chineseName = title && /[\u4e00-\u9fa5]/.test(title) ? title : null;
     const desktopContent = `[Desktop Entry]
@@ -2265,6 +2266,19 @@ async function convertIconFormat(inputPath, appName) {
         return null;
     }
 }
+async function isLinuxBundleIconReady(iconPath) {
+    if (!IS_LINUX || path.extname(iconPath).toLowerCase() !== '.png') {
+        return false;
+    }
+    try {
+        const { width, height } = await sharp(iconPath).metadata();
+        return (width === PLATFORM_CONFIG.linux.size &&
+            height === PLATFORM_CONFIG.linux.size);
+    }
+    catch {
+        return false;
+    }
+}
 /**
  * Processes downloaded or local icon for platform-specific format
  */
@@ -2274,7 +2288,7 @@ async function processIcon(iconPath, appName) {
     // Check if already in correct platform format
     const ext = path.extname(iconPath).toLowerCase();
     const isCorrectFormat = (IS_WIN && ext === '.ico') ||
-        (IS_LINUX && ext === '.png') ||
+        (IS_LINUX && (await isLinuxBundleIconReady(iconPath))) ||
         (!IS_WIN && !IS_LINUX && ext === '.icns');
     if (isCorrectFormat) {
         return await copyWindowsIconIfNeeded(iconPath, appName);

--- a/tests/unit/linux-desktop.test.ts
+++ b/tests/unit/linux-desktop.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildLinuxDesktopContent } from '../../bin/helpers/merge';
+
+describe('buildLinuxDesktopContent', () => {
+  it('uses the Tauri main binary name for freedesktop icon lookup', () => {
+    const desktopContent = buildLinuxDesktopContent(
+      'Example App',
+      undefined,
+      'pake-example-app',
+    );
+
+    expect(desktopContent).toContain('Exec=pake-example-app');
+    expect(desktopContent).toContain('Icon=pake-example-app');
+    expect(desktopContent).not.toContain('Icon=example-app_512');
+  });
+
+  it('keeps the localized Chinese name when title contains Chinese text', () => {
+    const desktopContent = buildLinuxDesktopContent(
+      'MiaoYan',
+      '妙言',
+      'pake-miaoyan',
+    );
+
+    expect(desktopContent).toContain('Name=MiaoYan');
+    expect(desktopContent).toContain('Name[zh_CN]=妙言');
+  });
+});

--- a/tests/unit/linux-icon.test.ts
+++ b/tests/unit/linux-icon.test.ts
@@ -1,0 +1,81 @@
+import os from 'os';
+import path from 'path';
+import fsExtra from 'fs-extra';
+import sharp from 'sharp';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_PAKE_OPTIONS } from '../../bin/defaults';
+import type { PakeAppOptions } from '../../bin/types';
+
+const tempDirs: string[] = [];
+
+async function makeTempDir() {
+  const tempDir = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'pake-icon-'));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+async function makePngIcon(size: number): Promise<string> {
+  const tempDir = await makeTempDir();
+  const iconPath = path.join(tempDir, `icon-${size}.png`);
+  await sharp({
+    create: {
+      width: size,
+      height: size,
+      channels: 4,
+      background: { r: 40, g: 120, b: 220, alpha: 1 },
+    },
+  })
+    .png()
+    .toFile(iconPath);
+  return iconPath;
+}
+
+async function importLinuxIconModule() {
+  vi.resetModules();
+  vi.doMock('@/utils/platform', () => ({
+    IS_MAC: false,
+    IS_WIN: false,
+    IS_LINUX: true,
+  }));
+  return await import('../../bin/options/icon');
+}
+
+function makeOptions(icon: string): PakeAppOptions {
+  return {
+    ...DEFAULT_PAKE_OPTIONS,
+    identifier: 'com.pake.test',
+    name: 'Linux App',
+    icon,
+  };
+}
+
+describe('Linux icon handling', () => {
+  afterEach(async () => {
+    vi.doUnmock('@/utils/platform');
+    vi.resetModules();
+    await Promise.all(tempDirs.splice(0).map((dir) => fsExtra.remove(dir)));
+  });
+
+  it('keeps a 512px PNG icon without reconverting it', async () => {
+    const sourceIcon = await makePngIcon(512);
+    const { handleIcon } = await importLinuxIconModule();
+
+    await expect(handleIcon(makeOptions(sourceIcon))).resolves.toBe(sourceIcon);
+  });
+
+  it('converts a non-512px PNG icon to a Linux bundle-ready icon', async () => {
+    const sourceIcon = await makePngIcon(128);
+    const { handleIcon } = await importLinuxIconModule();
+
+    const result = await handleIcon(makeOptions(sourceIcon));
+    const metadata = await sharp(result).metadata();
+    const generatedRoot = path.dirname(path.dirname(result));
+    tempDirs.push(generatedRoot);
+
+    expect(result).not.toBe(sourceIcon);
+    expect(path.basename(result)).toBe('linux-app_512.png');
+    expect(metadata.width).toBe(512);
+    expect(metadata.height).toBe(512);
+  });
+});


### PR DESCRIPTION
Updated the icon name assignment in the Linux configuration to use the main binary name instead of a PNG filename. Added a new function to validate if the Linux bundle icon is ready by checking its dimensions. Adjusted the icon format processing logic to utilize this validation for Linux, ensuring correct icon handling across platforms.