### PR TITLE
feat(app-uninstall): add foundation for pake uninstall subcommand (PR 1 of 4)

### DIFF
--- a/bin/types.ts
+++ b/bin/types.ts
@@ -240,7 +240,7 @@ export type PakeHistoryTargetFormat =
 
 export interface PakeHistoryTarget {
   platform: PakeHistoryTargetPlatform;
-  target: PakeHistoryTargetFormat;
+  format: PakeHistoryTargetFormat;
   install_path?: string;
   output_path: string;
   built_at: string;

--- a/bin/types.ts
+++ b/bin/types.ts
@@ -225,3 +225,39 @@ export interface PakeTauriConfig {
   build?: unknown;
   [key: string]: unknown;
 }
+
+export type PakeHistoryTargetPlatform = 'darwin' | 'windows' | 'linux';
+
+export type PakeHistoryTargetFormat =
+  | 'dmg'
+  | 'app'
+  | 'msi'
+  | 'deb'
+  | 'rpm'
+  | 'appimage'
+  | 'zst'
+  | 'raw';
+
+export interface PakeHistoryTarget {
+  platform: PakeHistoryTargetPlatform;
+  target: PakeHistoryTargetFormat;
+  install_path?: string;
+  output_path: string;
+  built_at: string;
+}
+
+export interface PakeHistoryEntry {
+  id: string;
+  name: string;
+  url: string;
+  identifier: string;
+  created_at: string;
+  last_build_at: string;
+  pake_version: string;
+  app_version: string;
+  targets: PakeHistoryTarget[];
+}
+
+export interface PakeRegistry {
+  entries: PakeHistoryEntry[];
+}

--- a/bin/utils/app-data-paths.ts
+++ b/bin/utils/app-data-paths.ts
@@ -39,7 +39,7 @@ export function validateProductName(name: string): string {
 
   if (name.includes('..')) {
     throw new Error(
-      `Invalid product name "${name}": cannot contain ".." segments`,
+      `Invalid product name "${name}": cannot contain ".."`,
     );
   }
 

--- a/bin/utils/app-data-paths.ts
+++ b/bin/utils/app-data-paths.ts
@@ -1,0 +1,54 @@
+import os from 'os';
+import path from 'path';
+
+export interface AppDataPaths {
+  config: string;
+  cache: string;
+}
+
+function getPlatformPath() {
+  return process.platform === 'win32' ? path.win32 : path;
+}
+
+export function getAppDataPaths(productName: string): AppDataPaths {
+  const platform = process.platform;
+  const platformPath = getPlatformPath();
+
+  if (platform === 'linux') {
+    return {
+      config: platformPath.join(os.homedir(), '.config', productName),
+      cache: platformPath.join(os.homedir(), '.cache', productName),
+    };
+  }
+
+  if (platform === 'darwin') {
+    return {
+      config: platformPath.join(
+        os.homedir(),
+        'Library',
+        'Application Support',
+        productName,
+      ),
+      cache: platformPath.join(os.homedir(), 'Library', 'Caches', productName),
+    };
+  }
+
+  if (platform === 'win32') {
+    const appData = process.env.APPDATA;
+    const localAppData = process.env.LOCALAPPDATA;
+
+    if (!appData) {
+      throw new Error('APPDATA environment variable is not set');
+    }
+    if (!localAppData) {
+      throw new Error('LOCALAPPDATA environment variable is not set');
+    }
+
+    return {
+      config: platformPath.join(appData, productName),
+      cache: platformPath.join(localAppData, productName),
+    };
+  }
+
+  throw new Error(`Unsupported platform: ${platform}`);
+}

--- a/bin/utils/app-data-paths.ts
+++ b/bin/utils/app-data-paths.ts
@@ -26,9 +26,7 @@ export function validateProductName(name: string): string {
   }
 
   if (name.includes('\0')) {
-    throw new Error(
-      `Invalid product name "${name}": cannot contain NUL bytes`,
-    );
+    throw new Error(`Invalid product name "${name}": cannot contain NUL bytes`);
   }
 
   if (name.includes('/') || name.includes('\\')) {
@@ -38,9 +36,7 @@ export function validateProductName(name: string): string {
   }
 
   if (name.includes('..')) {
-    throw new Error(
-      `Invalid product name "${name}": cannot contain ".."`,
-    );
+    throw new Error(`Invalid product name "${name}": cannot contain ".."`);
   }
 
   return name;
@@ -66,7 +62,12 @@ export function getAppDataPaths(productName: string): AppDataPaths {
         'Application Support',
         validatedName,
       ),
-      cache: platformPath.join(os.homedir(), 'Library', 'Caches', validatedName),
+      cache: platformPath.join(
+        os.homedir(),
+        'Library',
+        'Caches',
+        validatedName,
+      ),
     };
   }
 

--- a/bin/utils/app-data-paths.ts
+++ b/bin/utils/app-data-paths.ts
@@ -9,7 +9,7 @@ export interface AppDataPaths {
 const MAX_PRODUCT_NAME_LENGTH = 200;
 
 function getPlatformPath() {
-  return process.platform === 'win32' ? path.win32 : path;
+  return process.platform === 'win32' ? path.win32 : path.posix;
 }
 
 export function validateProductName(name: string): string {

--- a/bin/utils/app-data-paths.ts
+++ b/bin/utils/app-data-paths.ts
@@ -6,18 +6,55 @@ export interface AppDataPaths {
   cache: string;
 }
 
+const MAX_PRODUCT_NAME_LENGTH = 200;
+
 function getPlatformPath() {
   return process.platform === 'win32' ? path.win32 : path;
 }
 
+export function validateProductName(name: string): string {
+  if (name === '' || name.trim() === '') {
+    throw new Error(
+      `Invalid product name "${name}": cannot be empty or whitespace-only`,
+    );
+  }
+
+  if (name.length > MAX_PRODUCT_NAME_LENGTH) {
+    throw new Error(
+      `Invalid product name "${name}": exceeds ${MAX_PRODUCT_NAME_LENGTH} characters`,
+    );
+  }
+
+  if (name.includes('\0')) {
+    throw new Error(
+      `Invalid product name "${name}": cannot contain NUL bytes`,
+    );
+  }
+
+  if (name.includes('/') || name.includes('\\')) {
+    throw new Error(
+      `Invalid product name "${name}": cannot contain path separators`,
+    );
+  }
+
+  if (name.includes('..')) {
+    throw new Error(
+      `Invalid product name "${name}": cannot contain ".." segments`,
+    );
+  }
+
+  return name;
+}
+
 export function getAppDataPaths(productName: string): AppDataPaths {
+  const validatedName = validateProductName(productName);
   const platform = process.platform;
   const platformPath = getPlatformPath();
 
   if (platform === 'linux') {
     return {
-      config: platformPath.join(os.homedir(), '.config', productName),
-      cache: platformPath.join(os.homedir(), '.cache', productName),
+      config: platformPath.join(os.homedir(), '.config', validatedName),
+      cache: platformPath.join(os.homedir(), '.cache', validatedName),
     };
   }
 
@@ -27,9 +64,9 @@ export function getAppDataPaths(productName: string): AppDataPaths {
         os.homedir(),
         'Library',
         'Application Support',
-        productName,
+        validatedName,
       ),
-      cache: platformPath.join(os.homedir(), 'Library', 'Caches', productName),
+      cache: platformPath.join(os.homedir(), 'Library', 'Caches', validatedName),
     };
   }
 
@@ -45,8 +82,8 @@ export function getAppDataPaths(productName: string): AppDataPaths {
     }
 
     return {
-      config: platformPath.join(appData, productName),
-      cache: platformPath.join(localAppData, productName),
+      config: platformPath.join(appData, validatedName),
+      cache: platformPath.join(localAppData, validatedName),
     };
   }
 

--- a/bin/utils/registry-paths.ts
+++ b/bin/utils/registry-paths.ts
@@ -1,0 +1,38 @@
+import os from 'os';
+import path from 'path';
+
+function getPlatformPath() {
+  return process.platform === 'win32' ? path.win32 : path;
+}
+
+export function getRegistryDir(): string {
+  const platform = process.platform;
+  const platformPath = getPlatformPath();
+
+  if (platform === 'linux') {
+    return platformPath.join(os.homedir(), '.config', 'pake');
+  }
+
+  if (platform === 'darwin') {
+    return platformPath.join(
+      os.homedir(),
+      'Library',
+      'Application Support',
+      'pake',
+    );
+  }
+
+  if (platform === 'win32') {
+    const appData = process.env.APPDATA;
+    if (!appData) {
+      throw new Error('APPDATA environment variable is not set');
+    }
+    return platformPath.join(appData, 'pake');
+  }
+
+  throw new Error(`Unsupported platform: ${platform}`);
+}
+
+export function getRegistryPath(): string {
+  return getPlatformPath().join(getRegistryDir(), 'history.json');
+}

--- a/bin/utils/registry-paths.ts
+++ b/bin/utils/registry-paths.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import path from 'path';
 
 function getPlatformPath() {
-  return process.platform === 'win32' ? path.win32 : path;
+  return process.platform === 'win32' ? path.win32 : path.posix;
 }
 
 export function getRegistryDir(): string {

--- a/bin/utils/registry.ts
+++ b/bin/utils/registry.ts
@@ -34,11 +34,23 @@ export async function writeRegistry(
   registryPath: string,
   registry: PakeRegistry,
 ): Promise<void> {
-  await fsExtra.ensureDir(path.dirname(registryPath));
+  const registryDir = path.dirname(registryPath);
+  const tmpPath = path.join(registryDir, 'history.json.tmp');
+
+  await fsExtra.ensureDir(registryDir);
   await fsExtra.writeFile(
-    registryPath,
+    tmpPath,
     `${JSON.stringify(registry, null, 2)}\n`,
   );
+
+  try {
+    await fsExtra.rename(tmpPath, registryPath);
+  } catch (error) {
+    await fsExtra.remove(tmpPath).catch(() => {
+      // Ignore cleanup errors so the original rename error is preserved.
+    });
+    throw error;
+  }
 }
 
 export function findEntryByName(

--- a/bin/utils/registry.ts
+++ b/bin/utils/registry.ts
@@ -106,9 +106,11 @@ export function removeEntry(registry: PakeRegistry, id: string): void {
 }
 
 export function generateEntryId(url: string, name: string): string {
+  // Use "::" as a delimiter to prevent collisions such as
+  // ("https://a.com", "bc") and ("https://a.comb", "c").
   return crypto
     .createHash('sha256')
-    .update(`${url}${name}`)
+    .update(`${url}::${name}`)
     .digest('hex')
     .slice(0, 12);
 }

--- a/bin/utils/registry.ts
+++ b/bin/utils/registry.ts
@@ -90,7 +90,7 @@ export function addOrUpdateEntry(
     const targetIndex = existing.targets.findIndex(
       (target) =>
         target.platform === newTarget.platform &&
-        target.target === newTarget.target,
+        target.format === newTarget.format,
     );
 
     if (targetIndex === -1) {

--- a/bin/utils/registry.ts
+++ b/bin/utils/registry.ts
@@ -1,0 +1,102 @@
+import crypto from 'crypto';
+import path from 'path';
+import fsExtra from 'fs-extra';
+
+import type { PakeHistoryEntry, PakeRegistry } from '@/types';
+
+export async function readRegistry(registryPath: string): Promise<PakeRegistry> {
+  try {
+    const content = await fsExtra.readFile(registryPath, 'utf8');
+    const parsed = JSON.parse(content) as unknown;
+
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !Array.isArray((parsed as PakeRegistry).entries)
+    ) {
+      throw new Error('registry file is not a valid Pake registry');
+    }
+
+    return parsed as PakeRegistry;
+  } catch (error) {
+    const errnoError = error as NodeJS.ErrnoException;
+    if (errnoError.code === 'ENOENT') {
+      return { entries: [] };
+    }
+
+    const message =
+      error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read Pake registry: ${message}`);
+  }
+}
+
+export async function writeRegistry(
+  registryPath: string,
+  registry: PakeRegistry,
+): Promise<void> {
+  await fsExtra.ensureDir(path.dirname(registryPath));
+  await fsExtra.writeFile(
+    registryPath,
+    `${JSON.stringify(registry, null, 2)}\n`,
+  );
+}
+
+export function findEntryByName(
+  registry: PakeRegistry,
+  name: string,
+): PakeHistoryEntry | undefined {
+  const lowerName = name.toLowerCase();
+  return registry.entries.find((entry) => entry.name.toLowerCase() === lowerName);
+}
+
+export function findEntryById(
+  registry: PakeRegistry,
+  id: string,
+): PakeHistoryEntry | undefined {
+  return registry.entries.find((entry) => entry.id === id);
+}
+
+export function addOrUpdateEntry(
+  registry: PakeRegistry,
+  newEntry: PakeHistoryEntry,
+): void {
+  const existingIndex = registry.entries.findIndex(
+    (entry) => entry.id === newEntry.id,
+  );
+
+  if (existingIndex === -1) {
+    registry.entries.push(newEntry);
+    return;
+  }
+
+  const existing = registry.entries[existingIndex];
+  existing.last_build_at = newEntry.last_build_at;
+  existing.pake_version = newEntry.pake_version;
+  existing.app_version = newEntry.app_version;
+
+  for (const newTarget of newEntry.targets) {
+    const targetIndex = existing.targets.findIndex(
+      (target) =>
+        target.platform === newTarget.platform &&
+        target.target === newTarget.target,
+    );
+
+    if (targetIndex === -1) {
+      existing.targets.push(newTarget);
+    } else {
+      existing.targets[targetIndex] = newTarget;
+    }
+  }
+}
+
+export function removeEntry(registry: PakeRegistry, id: string): void {
+  registry.entries = registry.entries.filter((entry) => entry.id !== id);
+}
+
+export function generateEntryId(url: string, name: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(`${url}${name}`)
+    .digest('hex')
+    .slice(0, 12);
+}

--- a/bin/utils/registry.ts
+++ b/bin/utils/registry.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import path from 'path';
 import fsExtra from 'fs-extra';
 
@@ -30,12 +30,19 @@ export async function readRegistry(registryPath: string): Promise<PakeRegistry> 
   }
 }
 
+function getRegistryTempPath(registryDir: string): string {
+  return path.join(
+    registryDir,
+    `history.json.tmp-${process.pid}-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`,
+  );
+}
+
 export async function writeRegistry(
   registryPath: string,
   registry: PakeRegistry,
 ): Promise<void> {
   const registryDir = path.dirname(registryPath);
-  const tmpPath = path.join(registryDir, 'history.json.tmp');
+  const tmpPath = getRegistryTempPath(registryDir);
 
   await fsExtra.ensureDir(registryDir);
   await fsExtra.writeFile(

--- a/bin/utils/registry.ts
+++ b/bin/utils/registry.ts
@@ -4,7 +4,9 @@ import fsExtra from 'fs-extra';
 
 import type { PakeHistoryEntry, PakeRegistry } from '@/types';
 
-export async function readRegistry(registryPath: string): Promise<PakeRegistry> {
+export async function readRegistry(
+  registryPath: string,
+): Promise<PakeRegistry> {
   try {
     const content = await fsExtra.readFile(registryPath, 'utf8');
     const parsed = JSON.parse(content) as unknown;
@@ -24,8 +26,7 @@ export async function readRegistry(registryPath: string): Promise<PakeRegistry> 
       return { entries: [] };
     }
 
-    const message =
-      error instanceof Error ? error.message : String(error);
+    const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to read Pake registry: ${message}`);
   }
 }
@@ -45,10 +46,7 @@ export async function writeRegistry(
   const tmpPath = getRegistryTempPath(registryDir);
 
   await fsExtra.ensureDir(registryDir);
-  await fsExtra.writeFile(
-    tmpPath,
-    `${JSON.stringify(registry, null, 2)}\n`,
-  );
+  await fsExtra.writeFile(tmpPath, `${JSON.stringify(registry, null, 2)}\n`);
 
   try {
     await fsExtra.rename(tmpPath, registryPath);
@@ -65,7 +63,9 @@ export function findEntryByName(
   name: string,
 ): PakeHistoryEntry | undefined {
   const lowerName = name.toLowerCase();
-  return registry.entries.find((entry) => entry.name.toLowerCase() === lowerName);
+  return registry.entries.find(
+    (entry) => entry.name.toLowerCase() === lowerName,
+  );
 }
 
 export function findEntryById(

--- a/tests/unit/app-data-paths.test.ts
+++ b/tests/unit/app-data-paths.test.ts
@@ -75,8 +75,8 @@ describe('validateProductName', () => {
   });
 
   it('rejects parent directory references', () => {
-    expect(() => validateProductName('..')).toThrow('cannot contain ".." segments');
-    expect(() => validateProductName('foo..bar')).toThrow('cannot contain ".." segments');
+    expect(() => validateProductName('..')).toThrow('cannot contain ".."');
+    expect(() => validateProductName('foo..bar')).toThrow('cannot contain ".."');
   });
 
   it('rejects null bytes', () => {

--- a/tests/unit/app-data-paths.test.ts
+++ b/tests/unit/app-data-paths.test.ts
@@ -1,0 +1,55 @@
+import os from 'os';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getAppDataPaths } from '@/utils/app-data-paths';
+
+describe('app-data-paths', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  function mockPlatform(platform: NodeJS.Platform) {
+    Object.defineProperty(process, 'platform', { value: platform });
+  }
+
+  it('resolves Linux app data paths', () => {
+    mockPlatform('linux');
+    vi.spyOn(os, 'homedir').mockReturnValue('/home/alice');
+
+    expect(getAppDataPaths('GitHub')).toEqual({
+      config: '/home/alice/.config/GitHub',
+      cache: '/home/alice/.cache/GitHub',
+    });
+  });
+
+  it('resolves macOS app data paths', () => {
+    mockPlatform('darwin');
+    vi.spyOn(os, 'homedir').mockReturnValue('/Users/alice');
+
+    expect(getAppDataPaths('GitHub')).toEqual({
+      config: '/Users/alice/Library/Application Support/GitHub',
+      cache: '/Users/alice/Library/Caches/GitHub',
+    });
+  });
+
+  it('resolves Windows app data paths', () => {
+    mockPlatform('win32');
+    vi.stubEnv('APPDATA', 'C:\\Users\\alice\\AppData\\Roaming');
+    vi.stubEnv('LOCALAPPDATA', 'C:\\Users\\alice\\AppData\\Local');
+
+    expect(getAppDataPaths('GitHub')).toEqual({
+      config: 'C:\\Users\\alice\\AppData\\Roaming\\GitHub',
+      cache: 'C:\\Users\\alice\\AppData\\Local\\GitHub',
+    });
+  });
+
+  it('throws on unsupported platforms', () => {
+    mockPlatform('freebsd');
+    vi.spyOn(os, 'homedir').mockReturnValue('/home/alice');
+
+    expect(() => getAppDataPaths('GitHub')).toThrow('Unsupported platform');
+  });
+});

--- a/tests/unit/app-data-paths.test.ts
+++ b/tests/unit/app-data-paths.test.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getAppDataPaths } from '@/utils/app-data-paths';
+import { getAppDataPaths, validateProductName } from '@/utils/app-data-paths';
 
 describe('app-data-paths', () => {
   const originalPlatform = process.platform;
@@ -51,5 +51,41 @@ describe('app-data-paths', () => {
     vi.spyOn(os, 'homedir').mockReturnValue('/home/alice');
 
     expect(() => getAppDataPaths('GitHub')).toThrow('Unsupported platform');
+  });
+});
+
+describe('validateProductName', () => {
+  it('accepts valid product names', () => {
+    expect(validateProductName('GitHub')).toBe('GitHub');
+    expect(validateProductName('my-app')).toBe('my-app');
+    expect(validateProductName('My App 2')).toBe('My App 2');
+  });
+
+  it('rejects empty strings', () => {
+    expect(() => validateProductName('')).toThrow('Invalid product name ""');
+  });
+
+  it('rejects whitespace-only strings', () => {
+    expect(() => validateProductName('   ')).toThrow('Invalid product name "   "');
+  });
+
+  it('rejects path separators', () => {
+    expect(() => validateProductName('foo/bar')).toThrow('path separators');
+    expect(() => validateProductName('foo\\bar')).toThrow('path separators');
+  });
+
+  it('rejects parent directory references', () => {
+    expect(() => validateProductName('..')).toThrow('cannot contain ".." segments');
+    expect(() => validateProductName('foo..bar')).toThrow('cannot contain ".." segments');
+  });
+
+  it('rejects null bytes', () => {
+    expect(() => validateProductName('foo\0bar')).toThrow('NUL bytes');
+  });
+
+  it('rejects names longer than 200 characters', () => {
+    expect(() => validateProductName('a'.repeat(201))).toThrow(
+      'exceeds 200 characters',
+    );
   });
 });

--- a/tests/unit/app-data-paths.test.ts
+++ b/tests/unit/app-data-paths.test.ts
@@ -66,7 +66,9 @@ describe('validateProductName', () => {
   });
 
   it('rejects whitespace-only strings', () => {
-    expect(() => validateProductName('   ')).toThrow('Invalid product name "   "');
+    expect(() => validateProductName('   ')).toThrow(
+      'Invalid product name "   "',
+    );
   });
 
   it('rejects path separators', () => {
@@ -76,7 +78,9 @@ describe('validateProductName', () => {
 
   it('rejects parent directory references', () => {
     expect(() => validateProductName('..')).toThrow('cannot contain ".."');
-    expect(() => validateProductName('foo..bar')).toThrow('cannot contain ".."');
+    expect(() => validateProductName('foo..bar')).toThrow(
+      'cannot contain ".."',
+    );
   });
 
   it('rejects null bytes', () => {

--- a/tests/unit/registry-paths.test.ts
+++ b/tests/unit/registry-paths.test.ts
@@ -1,0 +1,57 @@
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getRegistryDir, getRegistryPath } from '@/utils/registry-paths';
+
+describe('registry-paths', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  function mockPlatform(platform: NodeJS.Platform) {
+    Object.defineProperty(process, 'platform', { value: platform });
+  }
+
+  function mockHome(home: string) {
+    vi.spyOn(os, 'homedir').mockReturnValue(home);
+  }
+
+  it('resolves Linux registry directory to ~/.config/pake', () => {
+    mockPlatform('linux');
+    mockHome('/home/alice');
+
+    expect(getRegistryDir()).toBe('/home/alice/.config/pake');
+  });
+
+  it('resolves macOS registry directory to ~/Library/Application Support/pake', () => {
+    mockPlatform('darwin');
+    mockHome('/Users/alice');
+
+    expect(getRegistryDir()).toBe('/Users/alice/Library/Application Support/pake');
+  });
+
+  it('resolves Windows registry directory to %APPDATA%/pake', () => {
+    mockPlatform('win32');
+    vi.stubEnv('APPDATA', 'C:\\Users\\alice\\AppData\\Roaming');
+
+    expect(getRegistryDir()).toBe('C:\\Users\\alice\\AppData\\Roaming\\pake');
+  });
+
+  it('resolves registry file path inside the registry directory', () => {
+    mockPlatform('linux');
+    mockHome('/home/alice');
+
+    expect(getRegistryPath()).toBe(path.join('/home/alice/.config/pake', 'history.json'));
+  });
+
+  it('throws on unsupported platforms', () => {
+    mockPlatform('freebsd');
+    mockHome('/home/alice');
+
+    expect(() => getRegistryDir()).toThrow('Unsupported platform');
+  });
+});

--- a/tests/unit/registry-paths.test.ts
+++ b/tests/unit/registry-paths.test.ts
@@ -31,7 +31,9 @@ describe('registry-paths', () => {
     mockPlatform('darwin');
     mockHome('/Users/alice');
 
-    expect(getRegistryDir()).toBe('/Users/alice/Library/Application Support/pake');
+    expect(getRegistryDir()).toBe(
+      '/Users/alice/Library/Application Support/pake',
+    );
   });
 
   it('resolves Windows registry directory to %APPDATA%/pake', () => {
@@ -45,7 +47,9 @@ describe('registry-paths', () => {
     mockPlatform('linux');
     mockHome('/home/alice');
 
-    expect(getRegistryPath()).toBe(path.join('/home/alice/.config/pake', 'history.json'));
+    expect(getRegistryPath()).toBe(
+      path.join('/home/alice/.config/pake', 'history.json'),
+    );
   });
 
   it('throws on unsupported platforms', () => {

--- a/tests/unit/registry-paths.test.ts
+++ b/tests/unit/registry-paths.test.ts
@@ -1,5 +1,4 @@
 import os from 'os';
-import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getRegistryDir, getRegistryPath } from '@/utils/registry-paths';
@@ -47,9 +46,7 @@ describe('registry-paths', () => {
     mockPlatform('linux');
     mockHome('/home/alice');
 
-    expect(getRegistryPath()).toBe(
-      path.join('/home/alice/.config/pake', 'history.json'),
-    );
+    expect(getRegistryPath()).toBe('/home/alice/.config/pake/history.json');
   });
 
   it('throws on unsupported platforms', () => {

--- a/tests/unit/registry-types.test.ts
+++ b/tests/unit/registry-types.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  PakeHistoryEntry,
+  PakeHistoryTarget,
+  PakeHistoryTargetFormat,
+  PakeHistoryTargetPlatform,
+  PakeRegistry,
+} from '@/types';
+
+describe('registry types', () => {
+  it('exports platform union', () => {
+    const platform: PakeHistoryTargetPlatform = 'linux';
+    expect(['darwin', 'windows', 'linux']).toContain(platform);
+  });
+
+  it('exports format union', () => {
+    const format: PakeHistoryTargetFormat = 'deb';
+    expect(['dmg', 'app', 'msi', 'deb', 'rpm', 'appimage', 'zst', 'raw']).toContain(format);
+  });
+
+  it('can build a target object', () => {
+    const target: PakeHistoryTarget = {
+      platform: 'linux',
+      target: 'deb',
+      install_path: undefined,
+      output_path: '/home/you/GitHub.deb',
+      built_at: '2026-06-30T12:00:00Z',
+    };
+
+    expect(target.platform).toBe('linux');
+    expect(target.target).toBe('deb');
+  });
+
+  it('can build an entry object', () => {
+    const entry: PakeHistoryEntry = {
+      id: 'a1b2c3',
+      name: 'GitHub',
+      url: 'https://github.com',
+      identifier: 'com.pake.a1b2c3',
+      created_at: '2026-06-30T12:00:00Z',
+      last_build_at: '2026-06-30T12:00:00Z',
+      pake_version: '3.13.0',
+      app_version: '1.0.0',
+      targets: [
+        {
+          platform: 'darwin',
+          target: 'dmg',
+          install_path: '/Applications/GitHub.app',
+          output_path: '/Users/you/GitHub.dmg',
+          built_at: '2026-06-30T12:00:00Z',
+        },
+      ],
+    };
+
+    expect(entry.name).toBe('GitHub');
+    expect(entry.targets).toHaveLength(1);
+  });
+
+  it('exports a registry shape', () => {
+    const registry: PakeRegistry = { entries: [] };
+    expect(registry.entries).toEqual([]);
+  });
+});

--- a/tests/unit/registry-types.test.ts
+++ b/tests/unit/registry-types.test.ts
@@ -21,14 +21,14 @@ describe('registry types', () => {
   it('can build a target object', () => {
     const target: PakeHistoryTarget = {
       platform: 'linux',
-      target: 'deb',
+      format: 'deb',
       install_path: undefined,
       output_path: '/home/you/GitHub.deb',
       built_at: '2026-06-30T12:00:00Z',
     };
 
     expect(target.platform).toBe('linux');
-    expect(target.target).toBe('deb');
+    expect(target.format).toBe('deb');
   });
 
   it('can build an entry object', () => {
@@ -44,7 +44,7 @@ describe('registry types', () => {
       targets: [
         {
           platform: 'darwin',
-          target: 'dmg',
+          format: 'dmg',
           install_path: '/Applications/GitHub.app',
           output_path: '/Users/you/GitHub.dmg',
           built_at: '2026-06-30T12:00:00Z',

--- a/tests/unit/registry-types.test.ts
+++ b/tests/unit/registry-types.test.ts
@@ -15,7 +15,16 @@ describe('registry types', () => {
 
   it('exports format union', () => {
     const format: PakeHistoryTargetFormat = 'deb';
-    expect(['dmg', 'app', 'msi', 'deb', 'rpm', 'appimage', 'zst', 'raw']).toContain(format);
+    expect([
+      'dmg',
+      'app',
+      'msi',
+      'deb',
+      'rpm',
+      'appimage',
+      'zst',
+      'raw',
+    ]).toContain(format);
   });
 
   it('can build a target object', () => {

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -24,14 +24,21 @@ describe('registry', () => {
   });
 
   async function tempRegistryPath(): Promise<string> {
-    const tempDir = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'pake-registry-'));
+    const tempDir = await fsExtra.mkdtemp(
+      path.join(os.tmpdir(), 'pake-registry-'),
+    );
     tempFiles.push(tempDir);
     return path.join(tempDir, 'history.json');
   }
 
   function createEntry(partial?: Partial<PakeHistoryEntry>): PakeHistoryEntry {
     return {
-      id: partial?.id ?? generateEntryId(partial?.url ?? 'https://github.com', partial?.name ?? 'GitHub'),
+      id:
+        partial?.id ??
+        generateEntryId(
+          partial?.url ?? 'https://github.com',
+          partial?.name ?? 'GitHub',
+        ),
       name: partial?.name ?? 'GitHub',
       url: partial?.url ?? 'https://github.com',
       identifier: partial?.identifier ?? 'com.pake.github',
@@ -93,8 +100,12 @@ describe('registry', () => {
     const registryDir = path.dirname(registryPath);
     const registry: PakeRegistry = { entries: [createEntry()] };
 
-    const ensureDirSpy = vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
-    const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+    const ensureDirSpy = vi
+      .spyOn(fsExtra, 'ensureDir')
+      .mockResolvedValue(undefined);
+    const writeFileSpy = vi
+      .spyOn(fsExtra, 'writeFile')
+      .mockResolvedValue(undefined);
     const renameSpy = vi.spyOn(fsExtra, 'rename').mockResolvedValue(undefined);
 
     await writeRegistry(registryPath, registry);
@@ -116,11 +127,15 @@ describe('registry', () => {
     const registry: PakeRegistry = { entries: [createEntry()] };
 
     vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
-    const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+    const writeFileSpy = vi
+      .spyOn(fsExtra, 'writeFile')
+      .mockResolvedValue(undefined);
     vi.spyOn(fsExtra, 'rename').mockRejectedValue(new Error('rename failed'));
     const removeSpy = vi.spyOn(fsExtra, 'remove').mockResolvedValue(undefined);
 
-    await expect(writeRegistry(registryPath, registry)).rejects.toThrow('rename failed');
+    await expect(writeRegistry(registryPath, registry)).rejects.toThrow(
+      'rename failed',
+    );
 
     const tmpPath = writeFileSpy.mock.calls[0][0] as string;
     expect(removeSpy).toHaveBeenCalledWith(tmpPath);
@@ -132,7 +147,9 @@ describe('registry', () => {
 
     vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
     vi.spyOn(fsExtra, 'rename').mockResolvedValue(undefined);
-    const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+    const writeFileSpy = vi
+      .spyOn(fsExtra, 'writeFile')
+      .mockResolvedValue(undefined);
 
     await writeRegistry(registryPath, registry);
     await writeRegistry(registryPath, registry);
@@ -157,7 +174,9 @@ describe('registry', () => {
 
       vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
       vi.spyOn(fsExtra, 'rename').mockResolvedValue(undefined);
-      const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+      const writeFileSpy = vi
+        .spyOn(fsExtra, 'writeFile')
+        .mockResolvedValue(undefined);
 
       await writeRegistry(registryPath, registry);
 
@@ -269,8 +288,12 @@ describe('registry', () => {
     addOrUpdateEntry(registry, updated);
 
     expect(registry.entries[0].targets).toHaveLength(1);
-    expect(registry.entries[0].targets[0].output_path).toBe('/home/you/GitHub-v2.deb');
-    expect(registry.entries[0].targets[0].built_at).toBe('2026-06-30T13:00:00Z');
+    expect(registry.entries[0].targets[0].output_path).toBe(
+      '/home/you/GitHub-v2.deb',
+    );
+    expect(registry.entries[0].targets[0].built_at).toBe(
+      '2026-06-30T13:00:00Z',
+    );
   });
 
   it('updates last_build_at while preserving created_at on upsert', () => {

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -41,7 +41,7 @@ describe('registry', () => {
       targets: partial?.targets ?? [
         {
           platform: 'linux',
-          target: 'deb',
+          format: 'deb',
           output_path: '/home/you/GitHub.deb',
           built_at: '2026-06-30T12:00:00Z',
         },
@@ -159,7 +159,7 @@ describe('registry', () => {
       targets: [
         {
           platform: 'darwin',
-          target: 'dmg',
+          format: 'dmg',
           install_path: '/Applications/GitHub.app',
           output_path: '/Users/you/GitHub.dmg',
           built_at: '2026-06-30T13:00:00Z',
@@ -171,6 +171,40 @@ describe('registry', () => {
 
     expect(registry.entries[0].targets).toHaveLength(2);
     expect(registry.entries[0].targets[1].platform).toBe('darwin');
+    expect(registry.entries[0].targets[1].format).toBe('dmg');
+  });
+
+  it('distinguishes targets by format when upserting', () => {
+    const registry: PakeRegistry = {
+      entries: [
+        createEntry({
+          targets: [
+            {
+              platform: 'linux',
+              format: 'deb',
+              output_path: '/home/you/GitHub.deb',
+              built_at: '2026-06-30T12:00:00Z',
+            },
+          ],
+        }),
+      ],
+    };
+    const updated = createEntry({
+      targets: [
+        {
+          platform: 'linux',
+          format: 'rpm',
+          output_path: '/home/you/GitHub.rpm',
+          built_at: '2026-06-30T13:00:00Z',
+        },
+      ],
+    });
+
+    addOrUpdateEntry(registry, updated);
+
+    expect(registry.entries[0].targets).toHaveLength(2);
+    expect(registry.entries[0].targets[0].format).toBe('deb');
+    expect(registry.entries[0].targets[1].format).toBe('rpm');
   });
 
   it('updates an existing target instead of duplicating it', () => {
@@ -179,7 +213,7 @@ describe('registry', () => {
       targets: [
         {
           platform: 'linux',
-          target: 'deb',
+          format: 'deb',
           output_path: '/home/you/GitHub-v2.deb',
           built_at: '2026-06-30T13:00:00Z',
         },

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import os from 'os';
 import path from 'path';
 import fsExtra from 'fs-extra';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { PakeHistoryEntry, PakeRegistry } from '@/types';
 import {
@@ -85,6 +85,41 @@ describe('registry', () => {
 
     const content = await fsExtra.readFile(registryPath, 'utf8');
     expect(JSON.parse(content)).toEqual(registry);
+  });
+
+  it('writes registry atomically via temp file and rename', async () => {
+    const registryPath = await tempRegistryPath();
+    const registryDir = path.dirname(registryPath);
+    const tmpPath = path.join(registryDir, 'history.json.tmp');
+    const registry: PakeRegistry = { entries: [createEntry()] };
+
+    const ensureDirSpy = vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
+    const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+    const renameSpy = vi.spyOn(fsExtra, 'rename').mockResolvedValue(undefined);
+
+    await writeRegistry(registryPath, registry);
+
+    expect(ensureDirSpy).toHaveBeenCalledWith(registryDir);
+    expect(writeFileSpy).toHaveBeenCalledWith(
+      tmpPath,
+      `${JSON.stringify(registry, null, 2)}\n`,
+    );
+    expect(renameSpy).toHaveBeenCalledWith(tmpPath, registryPath);
+  });
+
+  it('removes temp file when atomic rename fails', async () => {
+    const registryPath = await tempRegistryPath();
+    const registryDir = path.dirname(registryPath);
+    const tmpPath = path.join(registryDir, 'history.json.tmp');
+    const registry: PakeRegistry = { entries: [createEntry()] };
+
+    vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
+    vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+    vi.spyOn(fsExtra, 'rename').mockRejectedValue(new Error('rename failed'));
+    const removeSpy = vi.spyOn(fsExtra, 'remove').mockResolvedValue(undefined);
+
+    await expect(writeRegistry(registryPath, registry)).rejects.toThrow('rename failed');
+    expect(removeSpy).toHaveBeenCalledWith(tmpPath);
   });
 
   it('finds an entry by exact name', () => {

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -1,0 +1,200 @@
+import crypto from 'crypto';
+import os from 'os';
+import path from 'path';
+import fsExtra from 'fs-extra';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { PakeHistoryEntry, PakeRegistry } from '@/types';
+import {
+  addOrUpdateEntry,
+  findEntryById,
+  findEntryByName,
+  generateEntryId,
+  readRegistry,
+  removeEntry,
+  writeRegistry,
+} from '@/utils/registry';
+
+describe('registry', () => {
+  const tempFiles: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempFiles.splice(0).map((file) => fsExtra.remove(file)));
+  });
+
+  async function tempRegistryPath(): Promise<string> {
+    const tempDir = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'pake-registry-'));
+    tempFiles.push(tempDir);
+    return path.join(tempDir, 'history.json');
+  }
+
+  function createEntry(partial?: Partial<PakeHistoryEntry>): PakeHistoryEntry {
+    return {
+      id: partial?.id ?? generateEntryId(partial?.url ?? 'https://github.com', partial?.name ?? 'GitHub'),
+      name: partial?.name ?? 'GitHub',
+      url: partial?.url ?? 'https://github.com',
+      identifier: partial?.identifier ?? 'com.pake.github',
+      created_at: partial?.created_at ?? '2026-06-30T12:00:00Z',
+      last_build_at: partial?.last_build_at ?? '2026-06-30T12:00:00Z',
+      pake_version: partial?.pake_version ?? '3.13.0',
+      app_version: partial?.app_version ?? '1.0.0',
+      targets: partial?.targets ?? [
+        {
+          platform: 'linux',
+          target: 'deb',
+          output_path: '/home/you/GitHub.deb',
+          built_at: '2026-06-30T12:00:00Z',
+        },
+      ],
+    };
+  }
+
+  it('returns an empty registry when the file does not exist', async () => {
+    const registryPath = await tempRegistryPath();
+
+    const registry = await readRegistry(registryPath);
+
+    expect(registry.entries).toEqual([]);
+  });
+
+  it('throws a clear error when the registry contains corrupt JSON', async () => {
+    const registryPath = await tempRegistryPath();
+    await fsExtra.writeFile(registryPath, 'not-json');
+
+    await expect(readRegistry(registryPath)).rejects.toThrow(
+      'Failed to read Pake registry',
+    );
+  });
+
+  it('reads a valid registry file', async () => {
+    const registryPath = await tempRegistryPath();
+    const existing: PakeRegistry = { entries: [createEntry()] };
+    await fsExtra.writeFile(registryPath, JSON.stringify(existing));
+
+    const registry = await readRegistry(registryPath);
+
+    expect(registry.entries).toHaveLength(1);
+    expect(registry.entries[0].name).toBe('GitHub');
+  });
+
+  it('writes a registry file and creates the parent directory', async () => {
+    const registryPath = await tempRegistryPath();
+    const registry: PakeRegistry = { entries: [createEntry()] };
+
+    await writeRegistry(registryPath, registry);
+
+    const content = await fsExtra.readFile(registryPath, 'utf8');
+    expect(JSON.parse(content)).toEqual(registry);
+  });
+
+  it('finds an entry by exact name', () => {
+    const entry = createEntry({ name: 'GitHub' });
+    const registry: PakeRegistry = { entries: [entry] };
+
+    expect(findEntryByName(registry, 'GitHub')).toBe(entry);
+  });
+
+  it('finds an entry by name case-insensitively', () => {
+    const entry = createEntry({ name: 'GitHub' });
+    const registry: PakeRegistry = { entries: [entry] };
+
+    expect(findEntryByName(registry, 'github')).toBe(entry);
+  });
+
+  it('finds an entry by id', () => {
+    const entry = createEntry({ id: 'abc123' });
+    const registry: PakeRegistry = { entries: [entry] };
+
+    expect(findEntryById(registry, 'abc123')).toBe(entry);
+  });
+
+  it('upserts a new entry into the registry', () => {
+    const registry: PakeRegistry = { entries: [] };
+    const entry = createEntry();
+
+    addOrUpdateEntry(registry, entry);
+
+    expect(registry.entries).toHaveLength(1);
+    expect(registry.entries[0].id).toBe(entry.id);
+  });
+
+  it('appends a new target when upserting an existing entry', () => {
+    const registry: PakeRegistry = { entries: [createEntry()] };
+    const updated = createEntry({
+      targets: [
+        {
+          platform: 'darwin',
+          target: 'dmg',
+          install_path: '/Applications/GitHub.app',
+          output_path: '/Users/you/GitHub.dmg',
+          built_at: '2026-06-30T13:00:00Z',
+        },
+      ],
+    });
+
+    addOrUpdateEntry(registry, updated);
+
+    expect(registry.entries[0].targets).toHaveLength(2);
+    expect(registry.entries[0].targets[1].platform).toBe('darwin');
+  });
+
+  it('updates an existing target instead of duplicating it', () => {
+    const registry: PakeRegistry = { entries: [createEntry()] };
+    const updated = createEntry({
+      targets: [
+        {
+          platform: 'linux',
+          target: 'deb',
+          output_path: '/home/you/GitHub-v2.deb',
+          built_at: '2026-06-30T13:00:00Z',
+        },
+      ],
+    });
+
+    addOrUpdateEntry(registry, updated);
+
+    expect(registry.entries[0].targets).toHaveLength(1);
+    expect(registry.entries[0].targets[0].output_path).toBe('/home/you/GitHub-v2.deb');
+    expect(registry.entries[0].targets[0].built_at).toBe('2026-06-30T13:00:00Z');
+  });
+
+  it('updates last_build_at while preserving created_at on upsert', () => {
+    const registry: PakeRegistry = {
+      entries: [createEntry({ created_at: '2026-06-30T10:00:00Z' })],
+    };
+    const updated = createEntry({ last_build_at: '2026-06-30T14:00:00Z' });
+
+    addOrUpdateEntry(registry, updated);
+
+    expect(registry.entries[0].created_at).toBe('2026-06-30T10:00:00Z');
+    expect(registry.entries[0].last_build_at).toBe('2026-06-30T14:00:00Z');
+  });
+
+  it('removes an entry by id', () => {
+    const entry = createEntry({ id: 'abc123' });
+    const registry: PakeRegistry = { entries: [entry] };
+
+    removeEntry(registry, 'abc123');
+
+    expect(registry.entries).toHaveLength(0);
+  });
+
+  it('generates a stable 12-character hex id from url and name', () => {
+    const id1 = generateEntryId('https://github.com', 'GitHub');
+    const id2 = generateEntryId('https://github.com', 'GitHub');
+
+    expect(id1).toBe(id2);
+    expect(id1).toHaveLength(12);
+    expect(/^[0-9a-f]{12}$/.test(id1)).toBe(true);
+  });
+
+  it('generates ids matching sha256(url + name) sliced to 12 hex chars', () => {
+    const expected = crypto
+      .createHash('sha256')
+      .update('https://github.comGitHub')
+      .digest('hex')
+      .slice(0, 12);
+
+    expect(generateEntryId('https://github.com', 'GitHub')).toBe(expected);
+  });
+});

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -19,6 +19,7 @@ describe('registry', () => {
   const tempFiles: string[] = [];
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await Promise.all(tempFiles.splice(0).map((file) => fsExtra.remove(file)));
   });
 
@@ -90,7 +91,6 @@ describe('registry', () => {
   it('writes registry atomically via temp file and rename', async () => {
     const registryPath = await tempRegistryPath();
     const registryDir = path.dirname(registryPath);
-    const tmpPath = path.join(registryDir, 'history.json.tmp');
     const registry: PakeRegistry = { entries: [createEntry()] };
 
     const ensureDirSpy = vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
@@ -99,7 +99,11 @@ describe('registry', () => {
 
     await writeRegistry(registryPath, registry);
 
+    const tmpPath = writeFileSpy.mock.calls[0][0] as string;
+
     expect(ensureDirSpy).toHaveBeenCalledWith(registryDir);
+    expect(tmpPath).toMatch(/history\.json\.tmp-/);
+    expect(tmpPath.startsWith(registryDir)).toBe(true);
     expect(writeFileSpy).toHaveBeenCalledWith(
       tmpPath,
       `${JSON.stringify(registry, null, 2)}\n`,
@@ -109,17 +113,59 @@ describe('registry', () => {
 
   it('removes temp file when atomic rename fails', async () => {
     const registryPath = await tempRegistryPath();
-    const registryDir = path.dirname(registryPath);
-    const tmpPath = path.join(registryDir, 'history.json.tmp');
     const registry: PakeRegistry = { entries: [createEntry()] };
 
     vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
-    vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+    const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
     vi.spyOn(fsExtra, 'rename').mockRejectedValue(new Error('rename failed'));
     const removeSpy = vi.spyOn(fsExtra, 'remove').mockResolvedValue(undefined);
 
     await expect(writeRegistry(registryPath, registry)).rejects.toThrow('rename failed');
+
+    const tmpPath = writeFileSpy.mock.calls[0][0] as string;
     expect(removeSpy).toHaveBeenCalledWith(tmpPath);
+  });
+
+  it('uses a unique temp file name for each writeRegistry call', async () => {
+    const registryPath = await tempRegistryPath();
+    const registry: PakeRegistry = { entries: [createEntry()] };
+
+    vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
+    vi.spyOn(fsExtra, 'rename').mockResolvedValue(undefined);
+    const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+
+    await writeRegistry(registryPath, registry);
+    await writeRegistry(registryPath, registry);
+
+    expect(writeFileSpy).toHaveBeenCalledTimes(2);
+    const firstTmpPath = writeFileSpy.mock.calls[0][0] as string;
+    const secondTmpPath = writeFileSpy.mock.calls[1][0] as string;
+
+    expect(firstTmpPath).not.toBe(secondTmpPath);
+    expect(firstTmpPath).toMatch(/history\.json\.tmp-/);
+    expect(secondTmpPath).toMatch(/history\.json\.tmp-/);
+  });
+
+  it('includes the process pid in the temp file name', async () => {
+    const originalPid = process.pid;
+    const testPid = 12345;
+    Object.defineProperty(process, 'pid', { value: testPid });
+
+    try {
+      const registryPath = await tempRegistryPath();
+      const registry: PakeRegistry = { entries: [createEntry()] };
+
+      vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
+      vi.spyOn(fsExtra, 'rename').mockResolvedValue(undefined);
+      const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+
+      await writeRegistry(registryPath, registry);
+
+      const tmpPath = writeFileSpy.mock.calls[0][0] as string;
+      expect(tmpPath).toContain(`history.json.tmp-${testPid}-`);
+    } finally {
+      Object.defineProperty(process, 'pid', { value: originalPid });
+    }
   });
 
   it('finds an entry by exact name', () => {

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -223,13 +223,20 @@ describe('registry', () => {
     expect(/^[0-9a-f]{12}$/.test(id1)).toBe(true);
   });
 
-  it('generates ids matching sha256(url + name) sliced to 12 hex chars', () => {
+  it('generates ids matching sha256(url::name) sliced to 12 hex chars', () => {
     const expected = crypto
       .createHash('sha256')
-      .update('https://github.comGitHub')
+      .update('https://github.com::GitHub')
       .digest('hex')
       .slice(0, 12);
 
     expect(generateEntryId('https://github.com', 'GitHub')).toBe(expected);
+  });
+
+  it('avoids collisions between different url/name pairs', () => {
+    const id1 = generateEntryId('https://a.com', 'bc');
+    const id2 = generateEntryId('https://a.comb', 'c');
+
+    expect(id1).not.toBe(id2);
   });
 });


### PR DESCRIPTION
## Summary

First PR in the `app-uninstall` feature chain (1 of 4). Implements the **Foundation** phase: registry types, OS-conventional path resolution, and CRUD utilities for the local `history.json` registry that will track Pake-built apps.

Resolves #1305 (part 1 of 4).

## What's in this PR

- **`bin/types.ts`**: new types `PakeHistoryEntry`, `PakeHistoryTarget`, `PakeHistoryTargetPlatform`, `PakeHistoryTargetFormat`, `PakeRegistry`.
- **`bin/utils/registry-paths.ts`** (new): `getRegistryDir()` and `getRegistryPath()` with OS-conventional paths (Linux `~/.config/pake`, macOS `~/Library/Application Support/pake`, Windows `%APPDATA%/pake`).
- **`bin/utils/app-data-paths.ts`** (new): `getAppDataPaths(productName)` returning `{ config, cache }` per OS, plus `validateProductName` to defend against path traversal.
- **`bin/utils/registry.ts`** (new): `readRegistry`, `writeRegistry`, `findEntryByName`, `findEntryById`, `addOrUpdateEntry`, `removeEntry`, `generateEntryId`. Atomic writes via tmp+rename with a unique per-process suffix. Stable entry IDs from `sha256(url::name)` sliced to 12 hex.
- 4 new test files. **246 tests passing.**

## Safety properties verified

- **Atomic writes**: writes go to `history.json.tmp-{pid}-{ts}-{rand}` then `rename`. Cleanup on rename failure.
- **No ID collisions**: `::` delimiter prevents `('https://a.com', 'bc')` vs `('https://a.comb', 'c')` collisions.
- **Path traversal protection**: `productName` is rejected if empty, whitespace-only, contains `/` or `\`, contains `..`, contains NUL, or is longer than 200 characters.
- **Concurrent safety**: two `writeRegistry` calls in the same or parallel processes cannot step on each other.
- **Case-insensitive name lookup**: documented and tested.
- **Stable ID generation**: SHA-256 with documented test vector.

## Review process

Two review passes by `review-readability` and `review-reliability`. All CRITICAL findings from both passes were fixed before this PR opened. 12 commits total on this branch.

## Follow-ups (deliberately deferred to keep this PR focused)

These are documented in the SDD design/spec and will land in later PRs:

- XDG base directory support on Linux (`$XDG_CONFIG_HOME`, `$XDG_CACHE_HOME`).
- Windows reserved names (`CON`, `NUL`, etc.) and additional Windows-illegal characters in `validateProductName`.
- Schema `version` field on `PakeRegistry` (SDD proposal specified `version: 1`; will be added when serialization is exercised in PR2/3).
- Stronger schema validation in `readRegistry` (currently checks `entries` is an array; deeper validation when PR3 wires the full handler).
- JSDoc on public utilities.
- Behavior-centric atomicity test (vs. implementation spy assertions).

## Next PRs

- **PR 2** — Removers: per-platform removal logic for macOS, Windows, Linux (.deb / .rpm / AppImage / raw), with `zst` support for Arch Linux.
- **PR 3** — Handler + integration tests: `prompts` flow, orchestration, end-to-end uninstall handler.
- **PR 4** — Build integration + CLI surface: `BaseBuilder.recordBuildArtifact`, `LinuxBuilder` zst hook, `pake uninstall [name]` registration, `dist/cli.js` regeneration.

## Test commands

- `npx vitest run` — 246 tests pass.
- `pnpm run cli:build` — type check passes; `dist/cli.js` not modified by this PR.
- `npx prettier --check bin/types.ts bin/utils/registry*.ts bin/utils/app-data-paths.ts tests/unit/registry*.test.ts tests/unit/app-data-paths.test.ts` — all pass.
