### PR TITLE
feat(app-uninstall): add per-platform removers (PR 2 of 4)

### DIFF
--- a/bin/commands/uninstall/remover-darwin.ts
+++ b/bin/commands/uninstall/remover-darwin.ts
@@ -3,6 +3,20 @@ import chalk from 'chalk';
 import { PakeHistoryTarget } from '@/types';
 import { getAppDataPaths } from '@/utils/app-data-paths';
 
+/**
+ * macOS-specific uninstall helpers.
+ *
+ * macOS artifacts are file-based (`.app` bundles and `.dmg` installers), so
+ * removal is a direct filesystem operation. Missing paths are treated as
+ * already-removed and only produce a warning so the uninstall can continue.
+ */
+
+/**
+ * Remove the macOS app bundle and/or build artifact for a single target.
+ *
+ * @param target - The build target describing install_path and output_path.
+ * @returns A promise that resolves when removal succeeds or paths are missing.
+ */
 export async function removeDarwinBinary(
   target: PakeHistoryTarget,
 ): Promise<void> {
@@ -23,6 +37,12 @@ export async function removeDarwinBinary(
   }
 }
 
+/**
+ * Remove the macOS config and/or cache directories for an app.
+ *
+ * @param productName - The app name as recorded in the registry.
+ * @param categories - Flags selecting which data directories to remove.
+ */
 export async function removeDarwinData(
   productName: string,
   categories: { config: boolean; cache: boolean },

--- a/bin/commands/uninstall/remover-darwin.ts
+++ b/bin/commands/uninstall/remover-darwin.ts
@@ -1,0 +1,35 @@
+import fsExtra from 'fs-extra';
+import chalk from 'chalk';
+import { PakeHistoryTarget } from '@/types';
+import { getAppDataPaths } from '@/utils/app-data-paths';
+
+export async function removeDarwinBinary(target: PakeHistoryTarget): Promise<void> {
+  const paths: string[] = [];
+  if (target.install_path) {
+    paths.push(target.install_path);
+  }
+  paths.push(target.output_path);
+
+  for (const filePath of paths) {
+    if (await fsExtra.pathExists(filePath)) {
+      await fsExtra.remove(filePath);
+    } else {
+      console.warn(chalk.yellow(`Path ${filePath} does not exist, skipping...`));
+    }
+  }
+}
+
+export async function removeDarwinData(
+  productName: string,
+  categories: { config: boolean; cache: boolean },
+): Promise<void> {
+  const paths = getAppDataPaths(productName);
+
+  if (categories.config && (await fsExtra.pathExists(paths.config))) {
+    await fsExtra.remove(paths.config);
+  }
+
+  if (categories.cache && (await fsExtra.pathExists(paths.cache))) {
+    await fsExtra.remove(paths.cache);
+  }
+}

--- a/bin/commands/uninstall/remover-darwin.ts
+++ b/bin/commands/uninstall/remover-darwin.ts
@@ -3,7 +3,9 @@ import chalk from 'chalk';
 import { PakeHistoryTarget } from '@/types';
 import { getAppDataPaths } from '@/utils/app-data-paths';
 
-export async function removeDarwinBinary(target: PakeHistoryTarget): Promise<void> {
+export async function removeDarwinBinary(
+  target: PakeHistoryTarget,
+): Promise<void> {
   const paths: string[] = [];
   if (target.install_path) {
     paths.push(target.install_path);
@@ -14,7 +16,9 @@ export async function removeDarwinBinary(target: PakeHistoryTarget): Promise<voi
     if (await fsExtra.pathExists(filePath)) {
       await fsExtra.remove(filePath);
     } else {
-      console.warn(chalk.yellow(`Path ${filePath} does not exist, skipping...`));
+      console.warn(
+        chalk.yellow(`Path ${filePath} does not exist, skipping...`),
+      );
     }
   }
 }

--- a/bin/commands/uninstall/remover-linux.ts
+++ b/bin/commands/uninstall/remover-linux.ts
@@ -52,7 +52,9 @@ export async function removeLinuxBinary(
           await fsExtra.remove(target.output_path);
         } else {
           console.warn(
-            chalk.yellow(`Path ${target.output_path} does not exist, skipping...`),
+            chalk.yellow(
+              `Path ${target.output_path} does not exist, skipping...`,
+            ),
           );
         }
       } catch (error) {
@@ -68,7 +70,9 @@ export async function removeLinuxBinary(
   }
 
   if (errors.length > 0) {
-    throw new Error(`Failed to remove ${errors.length} path(s): ${errors.join('; ')}`);
+    throw new Error(
+      `Failed to remove ${errors.length} path(s): ${errors.join('; ')}`,
+    );
   }
 }
 

--- a/bin/commands/uninstall/remover-linux.ts
+++ b/bin/commands/uninstall/remover-linux.ts
@@ -4,13 +4,14 @@ import { execSync } from 'child_process';
 import { PakeHistoryTarget } from '@/types';
 import { getAppDataPaths } from '@/utils/app-data-paths';
 import { shellExec } from '@/utils/shell';
+import { generateLinuxPackageName } from '@/utils/name';
 
-export function normalizedPackageName(productName: string): string {
-  const normalized = productName
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-  return `pake-${normalized}`;
+function linuxPackageName(productName: string): string {
+  const base = generateLinuxPackageName(productName);
+  if (base.startsWith('pake-')) {
+    return base;
+  }
+  return `pake-${base}`;
 }
 
 function commandExists(command: string): boolean {
@@ -26,7 +27,7 @@ export async function removeLinuxBinary(
   productName: string,
   target: PakeHistoryTarget,
 ): Promise<void> {
-  const packageName = normalizedPackageName(productName);
+  const packageName = linuxPackageName(productName);
   const errors: string[] = [];
 
   switch (target.format) {

--- a/bin/commands/uninstall/remover-linux.ts
+++ b/bin/commands/uninstall/remover-linux.ts
@@ -16,7 +16,7 @@ function linuxPackageName(productName: string): string {
 
 function commandExists(command: string): boolean {
   try {
-    execSync(`which ${command}`, { stdio: 'ignore' });
+    execSync(`command -v ${command} >/dev/null 2>&1`, { stdio: 'ignore' });
     return true;
   } catch {
     return false;

--- a/bin/commands/uninstall/remover-linux.ts
+++ b/bin/commands/uninstall/remover-linux.ts
@@ -1,0 +1,88 @@
+import fsExtra from 'fs-extra';
+import chalk from 'chalk';
+import { execSync } from 'child_process';
+import { PakeHistoryTarget } from '@/types';
+import { getAppDataPaths } from '@/utils/app-data-paths';
+import { shellExec } from '@/utils/shell';
+
+export function normalizedPackageName(productName: string): string {
+  const normalized = productName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `pake-${normalized}`;
+}
+
+function commandExists(command: string): boolean {
+  try {
+    execSync(`which ${command}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function removeLinuxBinary(
+  productName: string,
+  target: PakeHistoryTarget,
+): Promise<void> {
+  const packageName = normalizedPackageName(productName);
+  const errors: string[] = [];
+
+  switch (target.format) {
+    case 'deb':
+      await shellExec(`sudo dpkg --remove ${packageName}`);
+      return;
+    case 'rpm':
+      await shellExec(`sudo rpm --erase ${packageName}`);
+      return;
+    case 'zst':
+      if (!commandExists('pacman')) {
+        console.warn(
+          chalk.yellow('pacman not found, skipping zst package removal'),
+        );
+        return;
+      }
+      await shellExec(`sudo pacman -R ${packageName}`);
+      return;
+    case 'appimage':
+    case 'raw':
+      try {
+        if (await fsExtra.pathExists(target.output_path)) {
+          await fsExtra.remove(target.output_path);
+        } else {
+          console.warn(
+            chalk.yellow(`Path ${target.output_path} does not exist, skipping...`),
+          );
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(
+          chalk.yellow(`Failed to remove ${target.output_path}: ${message}`),
+        );
+        errors.push(message);
+      }
+      break;
+    default:
+      throw new Error(`Unsupported Linux format: ${target.format}`);
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Failed to remove ${errors.length} path(s): ${errors.join('; ')}`);
+  }
+}
+
+export async function removeLinuxData(
+  productName: string,
+  categories: { config: boolean; cache: boolean },
+): Promise<void> {
+  const paths = getAppDataPaths(productName);
+
+  if (categories.config && (await fsExtra.pathExists(paths.config))) {
+    await fsExtra.remove(paths.config);
+  }
+
+  if (categories.cache && (await fsExtra.pathExists(paths.cache))) {
+    await fsExtra.remove(paths.cache);
+  }
+}

--- a/bin/commands/uninstall/remover-linux.ts
+++ b/bin/commands/uninstall/remover-linux.ts
@@ -6,6 +6,24 @@ import { getAppDataPaths } from '@/utils/app-data-paths';
 import { shellExec } from '@/utils/shell';
 import { generateLinuxPackageName } from '@/utils/name';
 
+/**
+ * Linux-specific uninstall helpers.
+ *
+ * Package-managed targets (deb, rpm, zst) are removed through the native package
+ * manager so that desktop entries, icons, and dependencies are cleaned up
+ * properly. File-based targets (AppImage, raw binary) are removed directly.
+ *
+ * Package-manager failures are allowed to propagate and abort the uninstall
+ * flow, which prevents config/cache directories from being deleted while a
+ * package-managed binary may still be registered with the system.
+ */
+
+/**
+ * Build the Linux package name used at build time.
+ *
+ * Reuses {@link generateLinuxPackageName} so that the uninstall command targets
+ * the exact package that `LinuxBuilder` / `BaseBuilder` created.
+ */
 function linuxPackageName(productName: string): string {
   const base = generateLinuxPackageName(productName);
   if (base.startsWith('pake-')) {
@@ -14,6 +32,12 @@ function linuxPackageName(productName: string): string {
   return `pake-${base}`;
 }
 
+/**
+ * Check whether a command is available in the current shell.
+ *
+ * Uses `command -v` instead of `which` because `which` is not guaranteed to be
+ * installed on minimal Linux distributions.
+ */
 function commandExists(command: string): boolean {
   try {
     execSync(`command -v ${command} >/dev/null 2>&1`, { stdio: 'ignore' });
@@ -23,6 +47,14 @@ function commandExists(command: string): boolean {
   }
 }
 
+/**
+ * Remove the Linux binary or package for a single build target.
+ *
+ * @param productName - The app name as recorded in the registry.
+ * @param target - The build target describing what was built and where.
+ * @returns A promise that resolves when removal succeeds.
+ * @throws When a package-manager command fails or a file removal fails.
+ */
 export async function removeLinuxBinary(
   productName: string,
   target: PakeHistoryTarget,
@@ -77,6 +109,12 @@ export async function removeLinuxBinary(
   }
 }
 
+/**
+ * Remove the Linux config and/or cache directories for an app.
+ *
+ * @param productName - The app name as recorded in the registry.
+ * @param categories - Flags selecting which data directories to remove.
+ */
 export async function removeLinuxData(
   productName: string,
   categories: { config: boolean; cache: boolean },

--- a/bin/commands/uninstall/remover-linux.ts
+++ b/bin/commands/uninstall/remover-linux.ts
@@ -21,15 +21,14 @@ import { generateLinuxPackageName } from '@/utils/name';
 /**
  * Build the Linux package name used at build time.
  *
- * Reuses {@link generateLinuxPackageName} so that the uninstall command targets
- * the exact package that `LinuxBuilder` / `BaseBuilder` created.
+ * Tauri v2 derives the package name for `.deb`/`.rpm` from `productName` via
+ * `heck::AsKebabCase` and the Arch `.pkg.tar.zst` `pkgname` is
+ * `generateLinuxPackageName(name)`. Pake's `merge.ts` only adds the `pake-`
+ * prefix to the **binary filename** (`mainBinaryName`), not to the package
+ * name. So the uninstaller must target the unprefixed name.
  */
 function linuxPackageName(productName: string): string {
-  const base = generateLinuxPackageName(productName);
-  if (base.startsWith('pake-')) {
-    return base;
-  }
-  return `pake-${base}`;
+  return generateLinuxPackageName(productName);
 }
 
 /**

--- a/bin/commands/uninstall/remover-windows.ts
+++ b/bin/commands/uninstall/remover-windows.ts
@@ -10,7 +10,9 @@ const REGISTRY_ROOTS = [
   'HKLM\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall',
 ];
 
-export function lookupWindowsProductCode(productName: string): string | undefined {
+export function lookupWindowsProductCode(
+  productName: string,
+): string | undefined {
   for (const root of REGISTRY_ROOTS) {
     try {
       const output = execSync(`reg query "${root}" /s /v DisplayName`, {
@@ -62,7 +64,9 @@ export async function removeWindowsBinary(
   if (await fsExtra.pathExists(target.output_path)) {
     await fsExtra.remove(target.output_path);
   } else {
-    console.warn(chalk.yellow(`Path ${target.output_path} does not exist, skipping...`));
+    console.warn(
+      chalk.yellow(`Path ${target.output_path} does not exist, skipping...`),
+    );
   }
 }
 

--- a/bin/commands/uninstall/remover-windows.ts
+++ b/bin/commands/uninstall/remover-windows.ts
@@ -10,6 +10,24 @@ const REGISTRY_ROOTS = [
   'HKLM\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall',
 ];
 
+/**
+ * Windows-specific uninstall helpers.
+ *
+ * Windows MSI targets are uninstalled through `msiexec /x` using the
+ * ProductCode stored in the registry. Non-MSI artifacts are removed as files.
+ * The registry is only read, never modified, and lookup failures fall back to
+ * direct file removal so that already-uninstalled apps do not block the flow.
+ */
+
+/**
+ * Look up the MSI ProductCode for an installed app by its DisplayName.
+ *
+ * Searches both the native and WOW6432Node uninstall registry hives so that
+ * 32-bit installers are found on 64-bit Windows.
+ *
+ * @param productName - The display name of the app to look up.
+ * @returns The ProductCode GUID if found, otherwise `undefined`.
+ */
 export function lookupWindowsProductCode(
   productName: string,
 ): string | undefined {
@@ -50,6 +68,14 @@ export function lookupWindowsProductCode(
   return undefined;
 }
 
+/**
+ * Remove the Windows binary or MSI installation for a single build target.
+ *
+ * @param productName - The app name as recorded in the registry.
+ * @param target - The build target describing what was built and where.
+ * @returns A promise that resolves when removal succeeds.
+ * @throws When `msiexec` fails or file removal fails.
+ */
 export async function removeWindowsBinary(
   productName: string,
   target: PakeHistoryTarget,
@@ -81,6 +107,12 @@ export async function removeWindowsBinary(
   }
 }
 
+/**
+ * Remove the Windows config and/or cache directories for an app.
+ *
+ * @param productName - The app name as recorded in the registry.
+ * @param categories - Flags selecting which data directories to remove.
+ */
 export async function removeWindowsData(
   productName: string,
   categories: { config: boolean; cache: boolean },

--- a/bin/commands/uninstall/remover-windows.ts
+++ b/bin/commands/uninstall/remover-windows.ts
@@ -1,0 +1,82 @@
+import fsExtra from 'fs-extra';
+import chalk from 'chalk';
+import { execSync } from 'child_process';
+import { PakeHistoryTarget } from '@/types';
+import { getAppDataPaths } from '@/utils/app-data-paths';
+import { shellExec } from '@/utils/shell';
+
+const REGISTRY_ROOTS = [
+  'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',
+  'HKLM\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall',
+];
+
+export function lookupWindowsProductCode(productName: string): string | undefined {
+  for (const root of REGISTRY_ROOTS) {
+    try {
+      const output = execSync(`reg query "${root}" /s /v DisplayName`, {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'ignore'],
+      });
+
+      const lines = output.split(/\r?\n/);
+      let currentKey: string | null = null;
+
+      for (const line of lines) {
+        const keyMatch = line.match(/^HKEY_LOCAL_MACHINE\\(.+)$/);
+        if (keyMatch) {
+          currentKey = keyMatch[1];
+          continue;
+        }
+
+        const displayNameMatch = line.match(/DisplayName\s+REG_SZ\s+(.+)$/);
+        if (
+          displayNameMatch &&
+          displayNameMatch[1].trim() === productName &&
+          currentKey
+        ) {
+          const guidMatch = currentKey.match(/{[A-F0-9-]+}/i);
+          if (guidMatch) {
+            return guidMatch[0];
+          }
+        }
+      }
+    } catch {
+      // Registry root may not exist or be inaccessible; continue to next root.
+    }
+  }
+
+  return undefined;
+}
+
+export async function removeWindowsBinary(
+  productName: string,
+  target: PakeHistoryTarget,
+): Promise<void> {
+  const productCode = lookupWindowsProductCode(productName);
+
+  if (productCode) {
+    await shellExec(`msiexec /x ${productCode} /qn /norestart`);
+    return;
+  }
+
+  if (await fsExtra.pathExists(target.output_path)) {
+    await fsExtra.remove(target.output_path);
+  } else {
+    console.warn(chalk.yellow(`Path ${target.output_path} does not exist, skipping...`));
+  }
+}
+
+export async function removeWindowsData(
+  productName: string,
+  categories: { config: boolean; cache: boolean },
+): Promise<void> {
+  const paths = getAppDataPaths(productName);
+
+  if (categories.config && (await fsExtra.pathExists(paths.config))) {
+    await fsExtra.remove(paths.config);
+  }
+
+  if (categories.cache && (await fsExtra.pathExists(paths.cache))) {
+    await fsExtra.remove(paths.cache);
+  }
+}

--- a/bin/commands/uninstall/remover-windows.ts
+++ b/bin/commands/uninstall/remover-windows.ts
@@ -54,6 +54,17 @@ export async function removeWindowsBinary(
   productName: string,
   target: PakeHistoryTarget,
 ): Promise<void> {
+  if (target.format !== 'msi') {
+    if (await fsExtra.pathExists(target.output_path)) {
+      await fsExtra.remove(target.output_path);
+    } else {
+      console.warn(
+        chalk.yellow(`Path ${target.output_path} does not exist, skipping...`),
+      );
+    }
+    return;
+  }
+
   const productCode = lookupWindowsProductCode(productName);
 
   if (productCode) {

--- a/bin/types.ts
+++ b/bin/types.ts
@@ -240,7 +240,7 @@ export type PakeHistoryTargetFormat =
 
 export interface PakeHistoryTarget {
   platform: PakeHistoryTargetPlatform;
-  target: PakeHistoryTargetFormat;
+  format: PakeHistoryTargetFormat;
   install_path?: string;
   output_path: string;
   built_at: string;

--- a/bin/types.ts
+++ b/bin/types.ts
@@ -225,3 +225,39 @@ export interface PakeTauriConfig {
   build?: unknown;
   [key: string]: unknown;
 }
+
+export type PakeHistoryTargetPlatform = 'darwin' | 'windows' | 'linux';
+
+export type PakeHistoryTargetFormat =
+  | 'dmg'
+  | 'app'
+  | 'msi'
+  | 'deb'
+  | 'rpm'
+  | 'appimage'
+  | 'zst'
+  | 'raw';
+
+export interface PakeHistoryTarget {
+  platform: PakeHistoryTargetPlatform;
+  target: PakeHistoryTargetFormat;
+  install_path?: string;
+  output_path: string;
+  built_at: string;
+}
+
+export interface PakeHistoryEntry {
+  id: string;
+  name: string;
+  url: string;
+  identifier: string;
+  created_at: string;
+  last_build_at: string;
+  pake_version: string;
+  app_version: string;
+  targets: PakeHistoryTarget[];
+}
+
+export interface PakeRegistry {
+  entries: PakeHistoryEntry[];
+}

--- a/bin/utils/app-data-paths.ts
+++ b/bin/utils/app-data-paths.ts
@@ -39,7 +39,7 @@ export function validateProductName(name: string): string {
 
   if (name.includes('..')) {
     throw new Error(
-      `Invalid product name "${name}": cannot contain ".." segments`,
+      `Invalid product name "${name}": cannot contain ".."`,
     );
   }
 

--- a/bin/utils/app-data-paths.ts
+++ b/bin/utils/app-data-paths.ts
@@ -1,0 +1,54 @@
+import os from 'os';
+import path from 'path';
+
+export interface AppDataPaths {
+  config: string;
+  cache: string;
+}
+
+function getPlatformPath() {
+  return process.platform === 'win32' ? path.win32 : path;
+}
+
+export function getAppDataPaths(productName: string): AppDataPaths {
+  const platform = process.platform;
+  const platformPath = getPlatformPath();
+
+  if (platform === 'linux') {
+    return {
+      config: platformPath.join(os.homedir(), '.config', productName),
+      cache: platformPath.join(os.homedir(), '.cache', productName),
+    };
+  }
+
+  if (platform === 'darwin') {
+    return {
+      config: platformPath.join(
+        os.homedir(),
+        'Library',
+        'Application Support',
+        productName,
+      ),
+      cache: platformPath.join(os.homedir(), 'Library', 'Caches', productName),
+    };
+  }
+
+  if (platform === 'win32') {
+    const appData = process.env.APPDATA;
+    const localAppData = process.env.LOCALAPPDATA;
+
+    if (!appData) {
+      throw new Error('APPDATA environment variable is not set');
+    }
+    if (!localAppData) {
+      throw new Error('LOCALAPPDATA environment variable is not set');
+    }
+
+    return {
+      config: platformPath.join(appData, productName),
+      cache: platformPath.join(localAppData, productName),
+    };
+  }
+
+  throw new Error(`Unsupported platform: ${platform}`);
+}

--- a/bin/utils/app-data-paths.ts
+++ b/bin/utils/app-data-paths.ts
@@ -26,9 +26,7 @@ export function validateProductName(name: string): string {
   }
 
   if (name.includes('\0')) {
-    throw new Error(
-      `Invalid product name "${name}": cannot contain NUL bytes`,
-    );
+    throw new Error(`Invalid product name "${name}": cannot contain NUL bytes`);
   }
 
   if (name.includes('/') || name.includes('\\')) {
@@ -38,9 +36,7 @@ export function validateProductName(name: string): string {
   }
 
   if (name.includes('..')) {
-    throw new Error(
-      `Invalid product name "${name}": cannot contain ".."`,
-    );
+    throw new Error(`Invalid product name "${name}": cannot contain ".."`);
   }
 
   return name;
@@ -66,7 +62,12 @@ export function getAppDataPaths(productName: string): AppDataPaths {
         'Application Support',
         validatedName,
       ),
-      cache: platformPath.join(os.homedir(), 'Library', 'Caches', validatedName),
+      cache: platformPath.join(
+        os.homedir(),
+        'Library',
+        'Caches',
+        validatedName,
+      ),
     };
   }
 

--- a/bin/utils/app-data-paths.ts
+++ b/bin/utils/app-data-paths.ts
@@ -9,7 +9,7 @@ export interface AppDataPaths {
 const MAX_PRODUCT_NAME_LENGTH = 200;
 
 function getPlatformPath() {
-  return process.platform === 'win32' ? path.win32 : path;
+  return process.platform === 'win32' ? path.win32 : path.posix;
 }
 
 export function validateProductName(name: string): string {

--- a/bin/utils/app-data-paths.ts
+++ b/bin/utils/app-data-paths.ts
@@ -6,18 +6,55 @@ export interface AppDataPaths {
   cache: string;
 }
 
+const MAX_PRODUCT_NAME_LENGTH = 200;
+
 function getPlatformPath() {
   return process.platform === 'win32' ? path.win32 : path;
 }
 
+export function validateProductName(name: string): string {
+  if (name === '' || name.trim() === '') {
+    throw new Error(
+      `Invalid product name "${name}": cannot be empty or whitespace-only`,
+    );
+  }
+
+  if (name.length > MAX_PRODUCT_NAME_LENGTH) {
+    throw new Error(
+      `Invalid product name "${name}": exceeds ${MAX_PRODUCT_NAME_LENGTH} characters`,
+    );
+  }
+
+  if (name.includes('\0')) {
+    throw new Error(
+      `Invalid product name "${name}": cannot contain NUL bytes`,
+    );
+  }
+
+  if (name.includes('/') || name.includes('\\')) {
+    throw new Error(
+      `Invalid product name "${name}": cannot contain path separators`,
+    );
+  }
+
+  if (name.includes('..')) {
+    throw new Error(
+      `Invalid product name "${name}": cannot contain ".." segments`,
+    );
+  }
+
+  return name;
+}
+
 export function getAppDataPaths(productName: string): AppDataPaths {
+  const validatedName = validateProductName(productName);
   const platform = process.platform;
   const platformPath = getPlatformPath();
 
   if (platform === 'linux') {
     return {
-      config: platformPath.join(os.homedir(), '.config', productName),
-      cache: platformPath.join(os.homedir(), '.cache', productName),
+      config: platformPath.join(os.homedir(), '.config', validatedName),
+      cache: platformPath.join(os.homedir(), '.cache', validatedName),
     };
   }
 
@@ -27,9 +64,9 @@ export function getAppDataPaths(productName: string): AppDataPaths {
         os.homedir(),
         'Library',
         'Application Support',
-        productName,
+        validatedName,
       ),
-      cache: platformPath.join(os.homedir(), 'Library', 'Caches', productName),
+      cache: platformPath.join(os.homedir(), 'Library', 'Caches', validatedName),
     };
   }
 
@@ -45,8 +82,8 @@ export function getAppDataPaths(productName: string): AppDataPaths {
     }
 
     return {
-      config: platformPath.join(appData, productName),
-      cache: platformPath.join(localAppData, productName),
+      config: platformPath.join(appData, validatedName),
+      cache: platformPath.join(localAppData, validatedName),
     };
   }
 

--- a/bin/utils/registry-paths.ts
+++ b/bin/utils/registry-paths.ts
@@ -1,0 +1,38 @@
+import os from 'os';
+import path from 'path';
+
+function getPlatformPath() {
+  return process.platform === 'win32' ? path.win32 : path;
+}
+
+export function getRegistryDir(): string {
+  const platform = process.platform;
+  const platformPath = getPlatformPath();
+
+  if (platform === 'linux') {
+    return platformPath.join(os.homedir(), '.config', 'pake');
+  }
+
+  if (platform === 'darwin') {
+    return platformPath.join(
+      os.homedir(),
+      'Library',
+      'Application Support',
+      'pake',
+    );
+  }
+
+  if (platform === 'win32') {
+    const appData = process.env.APPDATA;
+    if (!appData) {
+      throw new Error('APPDATA environment variable is not set');
+    }
+    return platformPath.join(appData, 'pake');
+  }
+
+  throw new Error(`Unsupported platform: ${platform}`);
+}
+
+export function getRegistryPath(): string {
+  return getPlatformPath().join(getRegistryDir(), 'history.json');
+}

--- a/bin/utils/registry-paths.ts
+++ b/bin/utils/registry-paths.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import path from 'path';
 
 function getPlatformPath() {
-  return process.platform === 'win32' ? path.win32 : path;
+  return process.platform === 'win32' ? path.win32 : path.posix;
 }
 
 export function getRegistryDir(): string {

--- a/bin/utils/registry.ts
+++ b/bin/utils/registry.ts
@@ -34,11 +34,23 @@ export async function writeRegistry(
   registryPath: string,
   registry: PakeRegistry,
 ): Promise<void> {
-  await fsExtra.ensureDir(path.dirname(registryPath));
+  const registryDir = path.dirname(registryPath);
+  const tmpPath = path.join(registryDir, 'history.json.tmp');
+
+  await fsExtra.ensureDir(registryDir);
   await fsExtra.writeFile(
-    registryPath,
+    tmpPath,
     `${JSON.stringify(registry, null, 2)}\n`,
   );
+
+  try {
+    await fsExtra.rename(tmpPath, registryPath);
+  } catch (error) {
+    await fsExtra.remove(tmpPath).catch(() => {
+      // Ignore cleanup errors so the original rename error is preserved.
+    });
+    throw error;
+  }
 }
 
 export function findEntryByName(

--- a/bin/utils/registry.ts
+++ b/bin/utils/registry.ts
@@ -106,9 +106,11 @@ export function removeEntry(registry: PakeRegistry, id: string): void {
 }
 
 export function generateEntryId(url: string, name: string): string {
+  // Use "::" as a delimiter to prevent collisions such as
+  // ("https://a.com", "bc") and ("https://a.comb", "c").
   return crypto
     .createHash('sha256')
-    .update(`${url}${name}`)
+    .update(`${url}::${name}`)
     .digest('hex')
     .slice(0, 12);
 }

--- a/bin/utils/registry.ts
+++ b/bin/utils/registry.ts
@@ -90,7 +90,7 @@ export function addOrUpdateEntry(
     const targetIndex = existing.targets.findIndex(
       (target) =>
         target.platform === newTarget.platform &&
-        target.target === newTarget.target,
+        target.format === newTarget.format,
     );
 
     if (targetIndex === -1) {

--- a/bin/utils/registry.ts
+++ b/bin/utils/registry.ts
@@ -1,0 +1,102 @@
+import crypto from 'crypto';
+import path from 'path';
+import fsExtra from 'fs-extra';
+
+import type { PakeHistoryEntry, PakeRegistry } from '@/types';
+
+export async function readRegistry(registryPath: string): Promise<PakeRegistry> {
+  try {
+    const content = await fsExtra.readFile(registryPath, 'utf8');
+    const parsed = JSON.parse(content) as unknown;
+
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !Array.isArray((parsed as PakeRegistry).entries)
+    ) {
+      throw new Error('registry file is not a valid Pake registry');
+    }
+
+    return parsed as PakeRegistry;
+  } catch (error) {
+    const errnoError = error as NodeJS.ErrnoException;
+    if (errnoError.code === 'ENOENT') {
+      return { entries: [] };
+    }
+
+    const message =
+      error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read Pake registry: ${message}`);
+  }
+}
+
+export async function writeRegistry(
+  registryPath: string,
+  registry: PakeRegistry,
+): Promise<void> {
+  await fsExtra.ensureDir(path.dirname(registryPath));
+  await fsExtra.writeFile(
+    registryPath,
+    `${JSON.stringify(registry, null, 2)}\n`,
+  );
+}
+
+export function findEntryByName(
+  registry: PakeRegistry,
+  name: string,
+): PakeHistoryEntry | undefined {
+  const lowerName = name.toLowerCase();
+  return registry.entries.find((entry) => entry.name.toLowerCase() === lowerName);
+}
+
+export function findEntryById(
+  registry: PakeRegistry,
+  id: string,
+): PakeHistoryEntry | undefined {
+  return registry.entries.find((entry) => entry.id === id);
+}
+
+export function addOrUpdateEntry(
+  registry: PakeRegistry,
+  newEntry: PakeHistoryEntry,
+): void {
+  const existingIndex = registry.entries.findIndex(
+    (entry) => entry.id === newEntry.id,
+  );
+
+  if (existingIndex === -1) {
+    registry.entries.push(newEntry);
+    return;
+  }
+
+  const existing = registry.entries[existingIndex];
+  existing.last_build_at = newEntry.last_build_at;
+  existing.pake_version = newEntry.pake_version;
+  existing.app_version = newEntry.app_version;
+
+  for (const newTarget of newEntry.targets) {
+    const targetIndex = existing.targets.findIndex(
+      (target) =>
+        target.platform === newTarget.platform &&
+        target.target === newTarget.target,
+    );
+
+    if (targetIndex === -1) {
+      existing.targets.push(newTarget);
+    } else {
+      existing.targets[targetIndex] = newTarget;
+    }
+  }
+}
+
+export function removeEntry(registry: PakeRegistry, id: string): void {
+  registry.entries = registry.entries.filter((entry) => entry.id !== id);
+}
+
+export function generateEntryId(url: string, name: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(`${url}${name}`)
+    .digest('hex')
+    .slice(0, 12);
+}

--- a/bin/utils/registry.ts
+++ b/bin/utils/registry.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import path from 'path';
 import fsExtra from 'fs-extra';
 
@@ -30,12 +30,19 @@ export async function readRegistry(registryPath: string): Promise<PakeRegistry> 
   }
 }
 
+function getRegistryTempPath(registryDir: string): string {
+  return path.join(
+    registryDir,
+    `history.json.tmp-${process.pid}-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`,
+  );
+}
+
 export async function writeRegistry(
   registryPath: string,
   registry: PakeRegistry,
 ): Promise<void> {
   const registryDir = path.dirname(registryPath);
-  const tmpPath = path.join(registryDir, 'history.json.tmp');
+  const tmpPath = getRegistryTempPath(registryDir);
 
   await fsExtra.ensureDir(registryDir);
   await fsExtra.writeFile(

--- a/bin/utils/registry.ts
+++ b/bin/utils/registry.ts
@@ -4,7 +4,9 @@ import fsExtra from 'fs-extra';
 
 import type { PakeHistoryEntry, PakeRegistry } from '@/types';
 
-export async function readRegistry(registryPath: string): Promise<PakeRegistry> {
+export async function readRegistry(
+  registryPath: string,
+): Promise<PakeRegistry> {
   try {
     const content = await fsExtra.readFile(registryPath, 'utf8');
     const parsed = JSON.parse(content) as unknown;
@@ -24,8 +26,7 @@ export async function readRegistry(registryPath: string): Promise<PakeRegistry> 
       return { entries: [] };
     }
 
-    const message =
-      error instanceof Error ? error.message : String(error);
+    const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to read Pake registry: ${message}`);
   }
 }
@@ -45,10 +46,7 @@ export async function writeRegistry(
   const tmpPath = getRegistryTempPath(registryDir);
 
   await fsExtra.ensureDir(registryDir);
-  await fsExtra.writeFile(
-    tmpPath,
-    `${JSON.stringify(registry, null, 2)}\n`,
-  );
+  await fsExtra.writeFile(tmpPath, `${JSON.stringify(registry, null, 2)}\n`);
 
   try {
     await fsExtra.rename(tmpPath, registryPath);
@@ -65,7 +63,9 @@ export function findEntryByName(
   name: string,
 ): PakeHistoryEntry | undefined {
   const lowerName = name.toLowerCase();
-  return registry.entries.find((entry) => entry.name.toLowerCase() === lowerName);
+  return registry.entries.find(
+    (entry) => entry.name.toLowerCase() === lowerName,
+  );
 }
 
 export function findEntryById(

--- a/tests/unit/app-data-paths.test.ts
+++ b/tests/unit/app-data-paths.test.ts
@@ -75,8 +75,8 @@ describe('validateProductName', () => {
   });
 
   it('rejects parent directory references', () => {
-    expect(() => validateProductName('..')).toThrow('cannot contain ".." segments');
-    expect(() => validateProductName('foo..bar')).toThrow('cannot contain ".." segments');
+    expect(() => validateProductName('..')).toThrow('cannot contain ".."');
+    expect(() => validateProductName('foo..bar')).toThrow('cannot contain ".."');
   });
 
   it('rejects null bytes', () => {

--- a/tests/unit/app-data-paths.test.ts
+++ b/tests/unit/app-data-paths.test.ts
@@ -1,0 +1,55 @@
+import os from 'os';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getAppDataPaths } from '@/utils/app-data-paths';
+
+describe('app-data-paths', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  function mockPlatform(platform: NodeJS.Platform) {
+    Object.defineProperty(process, 'platform', { value: platform });
+  }
+
+  it('resolves Linux app data paths', () => {
+    mockPlatform('linux');
+    vi.spyOn(os, 'homedir').mockReturnValue('/home/alice');
+
+    expect(getAppDataPaths('GitHub')).toEqual({
+      config: '/home/alice/.config/GitHub',
+      cache: '/home/alice/.cache/GitHub',
+    });
+  });
+
+  it('resolves macOS app data paths', () => {
+    mockPlatform('darwin');
+    vi.spyOn(os, 'homedir').mockReturnValue('/Users/alice');
+
+    expect(getAppDataPaths('GitHub')).toEqual({
+      config: '/Users/alice/Library/Application Support/GitHub',
+      cache: '/Users/alice/Library/Caches/GitHub',
+    });
+  });
+
+  it('resolves Windows app data paths', () => {
+    mockPlatform('win32');
+    vi.stubEnv('APPDATA', 'C:\\Users\\alice\\AppData\\Roaming');
+    vi.stubEnv('LOCALAPPDATA', 'C:\\Users\\alice\\AppData\\Local');
+
+    expect(getAppDataPaths('GitHub')).toEqual({
+      config: 'C:\\Users\\alice\\AppData\\Roaming\\GitHub',
+      cache: 'C:\\Users\\alice\\AppData\\Local\\GitHub',
+    });
+  });
+
+  it('throws on unsupported platforms', () => {
+    mockPlatform('freebsd');
+    vi.spyOn(os, 'homedir').mockReturnValue('/home/alice');
+
+    expect(() => getAppDataPaths('GitHub')).toThrow('Unsupported platform');
+  });
+});

--- a/tests/unit/app-data-paths.test.ts
+++ b/tests/unit/app-data-paths.test.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getAppDataPaths } from '@/utils/app-data-paths';
+import { getAppDataPaths, validateProductName } from '@/utils/app-data-paths';
 
 describe('app-data-paths', () => {
   const originalPlatform = process.platform;
@@ -51,5 +51,41 @@ describe('app-data-paths', () => {
     vi.spyOn(os, 'homedir').mockReturnValue('/home/alice');
 
     expect(() => getAppDataPaths('GitHub')).toThrow('Unsupported platform');
+  });
+});
+
+describe('validateProductName', () => {
+  it('accepts valid product names', () => {
+    expect(validateProductName('GitHub')).toBe('GitHub');
+    expect(validateProductName('my-app')).toBe('my-app');
+    expect(validateProductName('My App 2')).toBe('My App 2');
+  });
+
+  it('rejects empty strings', () => {
+    expect(() => validateProductName('')).toThrow('Invalid product name ""');
+  });
+
+  it('rejects whitespace-only strings', () => {
+    expect(() => validateProductName('   ')).toThrow('Invalid product name "   "');
+  });
+
+  it('rejects path separators', () => {
+    expect(() => validateProductName('foo/bar')).toThrow('path separators');
+    expect(() => validateProductName('foo\\bar')).toThrow('path separators');
+  });
+
+  it('rejects parent directory references', () => {
+    expect(() => validateProductName('..')).toThrow('cannot contain ".." segments');
+    expect(() => validateProductName('foo..bar')).toThrow('cannot contain ".." segments');
+  });
+
+  it('rejects null bytes', () => {
+    expect(() => validateProductName('foo\0bar')).toThrow('NUL bytes');
+  });
+
+  it('rejects names longer than 200 characters', () => {
+    expect(() => validateProductName('a'.repeat(201))).toThrow(
+      'exceeds 200 characters',
+    );
   });
 });

--- a/tests/unit/app-data-paths.test.ts
+++ b/tests/unit/app-data-paths.test.ts
@@ -66,7 +66,9 @@ describe('validateProductName', () => {
   });
 
   it('rejects whitespace-only strings', () => {
-    expect(() => validateProductName('   ')).toThrow('Invalid product name "   "');
+    expect(() => validateProductName('   ')).toThrow(
+      'Invalid product name "   "',
+    );
   });
 
   it('rejects path separators', () => {
@@ -76,7 +78,9 @@ describe('validateProductName', () => {
 
   it('rejects parent directory references', () => {
     expect(() => validateProductName('..')).toThrow('cannot contain ".."');
-    expect(() => validateProductName('foo..bar')).toThrow('cannot contain ".."');
+    expect(() => validateProductName('foo..bar')).toThrow(
+      'cannot contain ".."',
+    );
   });
 
   it('rejects null bytes', () => {

--- a/tests/unit/registry-paths.test.ts
+++ b/tests/unit/registry-paths.test.ts
@@ -1,0 +1,57 @@
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getRegistryDir, getRegistryPath } from '@/utils/registry-paths';
+
+describe('registry-paths', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  function mockPlatform(platform: NodeJS.Platform) {
+    Object.defineProperty(process, 'platform', { value: platform });
+  }
+
+  function mockHome(home: string) {
+    vi.spyOn(os, 'homedir').mockReturnValue(home);
+  }
+
+  it('resolves Linux registry directory to ~/.config/pake', () => {
+    mockPlatform('linux');
+    mockHome('/home/alice');
+
+    expect(getRegistryDir()).toBe('/home/alice/.config/pake');
+  });
+
+  it('resolves macOS registry directory to ~/Library/Application Support/pake', () => {
+    mockPlatform('darwin');
+    mockHome('/Users/alice');
+
+    expect(getRegistryDir()).toBe('/Users/alice/Library/Application Support/pake');
+  });
+
+  it('resolves Windows registry directory to %APPDATA%/pake', () => {
+    mockPlatform('win32');
+    vi.stubEnv('APPDATA', 'C:\\Users\\alice\\AppData\\Roaming');
+
+    expect(getRegistryDir()).toBe('C:\\Users\\alice\\AppData\\Roaming\\pake');
+  });
+
+  it('resolves registry file path inside the registry directory', () => {
+    mockPlatform('linux');
+    mockHome('/home/alice');
+
+    expect(getRegistryPath()).toBe(path.join('/home/alice/.config/pake', 'history.json'));
+  });
+
+  it('throws on unsupported platforms', () => {
+    mockPlatform('freebsd');
+    mockHome('/home/alice');
+
+    expect(() => getRegistryDir()).toThrow('Unsupported platform');
+  });
+});

--- a/tests/unit/registry-paths.test.ts
+++ b/tests/unit/registry-paths.test.ts
@@ -31,7 +31,9 @@ describe('registry-paths', () => {
     mockPlatform('darwin');
     mockHome('/Users/alice');
 
-    expect(getRegistryDir()).toBe('/Users/alice/Library/Application Support/pake');
+    expect(getRegistryDir()).toBe(
+      '/Users/alice/Library/Application Support/pake',
+    );
   });
 
   it('resolves Windows registry directory to %APPDATA%/pake', () => {
@@ -45,7 +47,9 @@ describe('registry-paths', () => {
     mockPlatform('linux');
     mockHome('/home/alice');
 
-    expect(getRegistryPath()).toBe(path.join('/home/alice/.config/pake', 'history.json'));
+    expect(getRegistryPath()).toBe(
+      path.join('/home/alice/.config/pake', 'history.json'),
+    );
   });
 
   it('throws on unsupported platforms', () => {

--- a/tests/unit/registry-paths.test.ts
+++ b/tests/unit/registry-paths.test.ts
@@ -1,5 +1,4 @@
 import os from 'os';
-import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getRegistryDir, getRegistryPath } from '@/utils/registry-paths';
@@ -47,9 +46,7 @@ describe('registry-paths', () => {
     mockPlatform('linux');
     mockHome('/home/alice');
 
-    expect(getRegistryPath()).toBe(
-      path.join('/home/alice/.config/pake', 'history.json'),
-    );
+    expect(getRegistryPath()).toBe('/home/alice/.config/pake/history.json');
   });
 
   it('throws on unsupported platforms', () => {

--- a/tests/unit/registry-types.test.ts
+++ b/tests/unit/registry-types.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  PakeHistoryEntry,
+  PakeHistoryTarget,
+  PakeHistoryTargetFormat,
+  PakeHistoryTargetPlatform,
+  PakeRegistry,
+} from '@/types';
+
+describe('registry types', () => {
+  it('exports platform union', () => {
+    const platform: PakeHistoryTargetPlatform = 'linux';
+    expect(['darwin', 'windows', 'linux']).toContain(platform);
+  });
+
+  it('exports format union', () => {
+    const format: PakeHistoryTargetFormat = 'deb';
+    expect(['dmg', 'app', 'msi', 'deb', 'rpm', 'appimage', 'zst', 'raw']).toContain(format);
+  });
+
+  it('can build a target object', () => {
+    const target: PakeHistoryTarget = {
+      platform: 'linux',
+      target: 'deb',
+      install_path: undefined,
+      output_path: '/home/you/GitHub.deb',
+      built_at: '2026-06-30T12:00:00Z',
+    };
+
+    expect(target.platform).toBe('linux');
+    expect(target.target).toBe('deb');
+  });
+
+  it('can build an entry object', () => {
+    const entry: PakeHistoryEntry = {
+      id: 'a1b2c3',
+      name: 'GitHub',
+      url: 'https://github.com',
+      identifier: 'com.pake.a1b2c3',
+      created_at: '2026-06-30T12:00:00Z',
+      last_build_at: '2026-06-30T12:00:00Z',
+      pake_version: '3.13.0',
+      app_version: '1.0.0',
+      targets: [
+        {
+          platform: 'darwin',
+          target: 'dmg',
+          install_path: '/Applications/GitHub.app',
+          output_path: '/Users/you/GitHub.dmg',
+          built_at: '2026-06-30T12:00:00Z',
+        },
+      ],
+    };
+
+    expect(entry.name).toBe('GitHub');
+    expect(entry.targets).toHaveLength(1);
+  });
+
+  it('exports a registry shape', () => {
+    const registry: PakeRegistry = { entries: [] };
+    expect(registry.entries).toEqual([]);
+  });
+});

--- a/tests/unit/registry-types.test.ts
+++ b/tests/unit/registry-types.test.ts
@@ -21,14 +21,14 @@ describe('registry types', () => {
   it('can build a target object', () => {
     const target: PakeHistoryTarget = {
       platform: 'linux',
-      target: 'deb',
+      format: 'deb',
       install_path: undefined,
       output_path: '/home/you/GitHub.deb',
       built_at: '2026-06-30T12:00:00Z',
     };
 
     expect(target.platform).toBe('linux');
-    expect(target.target).toBe('deb');
+    expect(target.format).toBe('deb');
   });
 
   it('can build an entry object', () => {
@@ -44,7 +44,7 @@ describe('registry types', () => {
       targets: [
         {
           platform: 'darwin',
-          target: 'dmg',
+          format: 'dmg',
           install_path: '/Applications/GitHub.app',
           output_path: '/Users/you/GitHub.dmg',
           built_at: '2026-06-30T12:00:00Z',

--- a/tests/unit/registry-types.test.ts
+++ b/tests/unit/registry-types.test.ts
@@ -15,7 +15,16 @@ describe('registry types', () => {
 
   it('exports format union', () => {
     const format: PakeHistoryTargetFormat = 'deb';
-    expect(['dmg', 'app', 'msi', 'deb', 'rpm', 'appimage', 'zst', 'raw']).toContain(format);
+    expect([
+      'dmg',
+      'app',
+      'msi',
+      'deb',
+      'rpm',
+      'appimage',
+      'zst',
+      'raw',
+    ]).toContain(format);
   });
 
   it('can build a target object', () => {

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -24,14 +24,21 @@ describe('registry', () => {
   });
 
   async function tempRegistryPath(): Promise<string> {
-    const tempDir = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'pake-registry-'));
+    const tempDir = await fsExtra.mkdtemp(
+      path.join(os.tmpdir(), 'pake-registry-'),
+    );
     tempFiles.push(tempDir);
     return path.join(tempDir, 'history.json');
   }
 
   function createEntry(partial?: Partial<PakeHistoryEntry>): PakeHistoryEntry {
     return {
-      id: partial?.id ?? generateEntryId(partial?.url ?? 'https://github.com', partial?.name ?? 'GitHub'),
+      id:
+        partial?.id ??
+        generateEntryId(
+          partial?.url ?? 'https://github.com',
+          partial?.name ?? 'GitHub',
+        ),
       name: partial?.name ?? 'GitHub',
       url: partial?.url ?? 'https://github.com',
       identifier: partial?.identifier ?? 'com.pake.github',
@@ -93,8 +100,12 @@ describe('registry', () => {
     const registryDir = path.dirname(registryPath);
     const registry: PakeRegistry = { entries: [createEntry()] };
 
-    const ensureDirSpy = vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
-    const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+    const ensureDirSpy = vi
+      .spyOn(fsExtra, 'ensureDir')
+      .mockResolvedValue(undefined);
+    const writeFileSpy = vi
+      .spyOn(fsExtra, 'writeFile')
+      .mockResolvedValue(undefined);
     const renameSpy = vi.spyOn(fsExtra, 'rename').mockResolvedValue(undefined);
 
     await writeRegistry(registryPath, registry);
@@ -116,11 +127,15 @@ describe('registry', () => {
     const registry: PakeRegistry = { entries: [createEntry()] };
 
     vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
-    const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+    const writeFileSpy = vi
+      .spyOn(fsExtra, 'writeFile')
+      .mockResolvedValue(undefined);
     vi.spyOn(fsExtra, 'rename').mockRejectedValue(new Error('rename failed'));
     const removeSpy = vi.spyOn(fsExtra, 'remove').mockResolvedValue(undefined);
 
-    await expect(writeRegistry(registryPath, registry)).rejects.toThrow('rename failed');
+    await expect(writeRegistry(registryPath, registry)).rejects.toThrow(
+      'rename failed',
+    );
 
     const tmpPath = writeFileSpy.mock.calls[0][0] as string;
     expect(removeSpy).toHaveBeenCalledWith(tmpPath);
@@ -132,7 +147,9 @@ describe('registry', () => {
 
     vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
     vi.spyOn(fsExtra, 'rename').mockResolvedValue(undefined);
-    const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+    const writeFileSpy = vi
+      .spyOn(fsExtra, 'writeFile')
+      .mockResolvedValue(undefined);
 
     await writeRegistry(registryPath, registry);
     await writeRegistry(registryPath, registry);
@@ -157,7 +174,9 @@ describe('registry', () => {
 
       vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
       vi.spyOn(fsExtra, 'rename').mockResolvedValue(undefined);
-      const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+      const writeFileSpy = vi
+        .spyOn(fsExtra, 'writeFile')
+        .mockResolvedValue(undefined);
 
       await writeRegistry(registryPath, registry);
 
@@ -269,8 +288,12 @@ describe('registry', () => {
     addOrUpdateEntry(registry, updated);
 
     expect(registry.entries[0].targets).toHaveLength(1);
-    expect(registry.entries[0].targets[0].output_path).toBe('/home/you/GitHub-v2.deb');
-    expect(registry.entries[0].targets[0].built_at).toBe('2026-06-30T13:00:00Z');
+    expect(registry.entries[0].targets[0].output_path).toBe(
+      '/home/you/GitHub-v2.deb',
+    );
+    expect(registry.entries[0].targets[0].built_at).toBe(
+      '2026-06-30T13:00:00Z',
+    );
   });
 
   it('updates last_build_at while preserving created_at on upsert', () => {

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -41,7 +41,7 @@ describe('registry', () => {
       targets: partial?.targets ?? [
         {
           platform: 'linux',
-          target: 'deb',
+          format: 'deb',
           output_path: '/home/you/GitHub.deb',
           built_at: '2026-06-30T12:00:00Z',
         },
@@ -159,7 +159,7 @@ describe('registry', () => {
       targets: [
         {
           platform: 'darwin',
-          target: 'dmg',
+          format: 'dmg',
           install_path: '/Applications/GitHub.app',
           output_path: '/Users/you/GitHub.dmg',
           built_at: '2026-06-30T13:00:00Z',
@@ -171,6 +171,40 @@ describe('registry', () => {
 
     expect(registry.entries[0].targets).toHaveLength(2);
     expect(registry.entries[0].targets[1].platform).toBe('darwin');
+    expect(registry.entries[0].targets[1].format).toBe('dmg');
+  });
+
+  it('distinguishes targets by format when upserting', () => {
+    const registry: PakeRegistry = {
+      entries: [
+        createEntry({
+          targets: [
+            {
+              platform: 'linux',
+              format: 'deb',
+              output_path: '/home/you/GitHub.deb',
+              built_at: '2026-06-30T12:00:00Z',
+            },
+          ],
+        }),
+      ],
+    };
+    const updated = createEntry({
+      targets: [
+        {
+          platform: 'linux',
+          format: 'rpm',
+          output_path: '/home/you/GitHub.rpm',
+          built_at: '2026-06-30T13:00:00Z',
+        },
+      ],
+    });
+
+    addOrUpdateEntry(registry, updated);
+
+    expect(registry.entries[0].targets).toHaveLength(2);
+    expect(registry.entries[0].targets[0].format).toBe('deb');
+    expect(registry.entries[0].targets[1].format).toBe('rpm');
   });
 
   it('updates an existing target instead of duplicating it', () => {
@@ -179,7 +213,7 @@ describe('registry', () => {
       targets: [
         {
           platform: 'linux',
-          target: 'deb',
+          format: 'deb',
           output_path: '/home/you/GitHub-v2.deb',
           built_at: '2026-06-30T13:00:00Z',
         },

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import os from 'os';
 import path from 'path';
 import fsExtra from 'fs-extra';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { PakeHistoryEntry, PakeRegistry } from '@/types';
 import {
@@ -85,6 +85,41 @@ describe('registry', () => {
 
     const content = await fsExtra.readFile(registryPath, 'utf8');
     expect(JSON.parse(content)).toEqual(registry);
+  });
+
+  it('writes registry atomically via temp file and rename', async () => {
+    const registryPath = await tempRegistryPath();
+    const registryDir = path.dirname(registryPath);
+    const tmpPath = path.join(registryDir, 'history.json.tmp');
+    const registry: PakeRegistry = { entries: [createEntry()] };
+
+    const ensureDirSpy = vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
+    const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+    const renameSpy = vi.spyOn(fsExtra, 'rename').mockResolvedValue(undefined);
+
+    await writeRegistry(registryPath, registry);
+
+    expect(ensureDirSpy).toHaveBeenCalledWith(registryDir);
+    expect(writeFileSpy).toHaveBeenCalledWith(
+      tmpPath,
+      `${JSON.stringify(registry, null, 2)}\n`,
+    );
+    expect(renameSpy).toHaveBeenCalledWith(tmpPath, registryPath);
+  });
+
+  it('removes temp file when atomic rename fails', async () => {
+    const registryPath = await tempRegistryPath();
+    const registryDir = path.dirname(registryPath);
+    const tmpPath = path.join(registryDir, 'history.json.tmp');
+    const registry: PakeRegistry = { entries: [createEntry()] };
+
+    vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
+    vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+    vi.spyOn(fsExtra, 'rename').mockRejectedValue(new Error('rename failed'));
+    const removeSpy = vi.spyOn(fsExtra, 'remove').mockResolvedValue(undefined);
+
+    await expect(writeRegistry(registryPath, registry)).rejects.toThrow('rename failed');
+    expect(removeSpy).toHaveBeenCalledWith(tmpPath);
   });
 
   it('finds an entry by exact name', () => {

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -1,0 +1,200 @@
+import crypto from 'crypto';
+import os from 'os';
+import path from 'path';
+import fsExtra from 'fs-extra';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { PakeHistoryEntry, PakeRegistry } from '@/types';
+import {
+  addOrUpdateEntry,
+  findEntryById,
+  findEntryByName,
+  generateEntryId,
+  readRegistry,
+  removeEntry,
+  writeRegistry,
+} from '@/utils/registry';
+
+describe('registry', () => {
+  const tempFiles: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempFiles.splice(0).map((file) => fsExtra.remove(file)));
+  });
+
+  async function tempRegistryPath(): Promise<string> {
+    const tempDir = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'pake-registry-'));
+    tempFiles.push(tempDir);
+    return path.join(tempDir, 'history.json');
+  }
+
+  function createEntry(partial?: Partial<PakeHistoryEntry>): PakeHistoryEntry {
+    return {
+      id: partial?.id ?? generateEntryId(partial?.url ?? 'https://github.com', partial?.name ?? 'GitHub'),
+      name: partial?.name ?? 'GitHub',
+      url: partial?.url ?? 'https://github.com',
+      identifier: partial?.identifier ?? 'com.pake.github',
+      created_at: partial?.created_at ?? '2026-06-30T12:00:00Z',
+      last_build_at: partial?.last_build_at ?? '2026-06-30T12:00:00Z',
+      pake_version: partial?.pake_version ?? '3.13.0',
+      app_version: partial?.app_version ?? '1.0.0',
+      targets: partial?.targets ?? [
+        {
+          platform: 'linux',
+          target: 'deb',
+          output_path: '/home/you/GitHub.deb',
+          built_at: '2026-06-30T12:00:00Z',
+        },
+      ],
+    };
+  }
+
+  it('returns an empty registry when the file does not exist', async () => {
+    const registryPath = await tempRegistryPath();
+
+    const registry = await readRegistry(registryPath);
+
+    expect(registry.entries).toEqual([]);
+  });
+
+  it('throws a clear error when the registry contains corrupt JSON', async () => {
+    const registryPath = await tempRegistryPath();
+    await fsExtra.writeFile(registryPath, 'not-json');
+
+    await expect(readRegistry(registryPath)).rejects.toThrow(
+      'Failed to read Pake registry',
+    );
+  });
+
+  it('reads a valid registry file', async () => {
+    const registryPath = await tempRegistryPath();
+    const existing: PakeRegistry = { entries: [createEntry()] };
+    await fsExtra.writeFile(registryPath, JSON.stringify(existing));
+
+    const registry = await readRegistry(registryPath);
+
+    expect(registry.entries).toHaveLength(1);
+    expect(registry.entries[0].name).toBe('GitHub');
+  });
+
+  it('writes a registry file and creates the parent directory', async () => {
+    const registryPath = await tempRegistryPath();
+    const registry: PakeRegistry = { entries: [createEntry()] };
+
+    await writeRegistry(registryPath, registry);
+
+    const content = await fsExtra.readFile(registryPath, 'utf8');
+    expect(JSON.parse(content)).toEqual(registry);
+  });
+
+  it('finds an entry by exact name', () => {
+    const entry = createEntry({ name: 'GitHub' });
+    const registry: PakeRegistry = { entries: [entry] };
+
+    expect(findEntryByName(registry, 'GitHub')).toBe(entry);
+  });
+
+  it('finds an entry by name case-insensitively', () => {
+    const entry = createEntry({ name: 'GitHub' });
+    const registry: PakeRegistry = { entries: [entry] };
+
+    expect(findEntryByName(registry, 'github')).toBe(entry);
+  });
+
+  it('finds an entry by id', () => {
+    const entry = createEntry({ id: 'abc123' });
+    const registry: PakeRegistry = { entries: [entry] };
+
+    expect(findEntryById(registry, 'abc123')).toBe(entry);
+  });
+
+  it('upserts a new entry into the registry', () => {
+    const registry: PakeRegistry = { entries: [] };
+    const entry = createEntry();
+
+    addOrUpdateEntry(registry, entry);
+
+    expect(registry.entries).toHaveLength(1);
+    expect(registry.entries[0].id).toBe(entry.id);
+  });
+
+  it('appends a new target when upserting an existing entry', () => {
+    const registry: PakeRegistry = { entries: [createEntry()] };
+    const updated = createEntry({
+      targets: [
+        {
+          platform: 'darwin',
+          target: 'dmg',
+          install_path: '/Applications/GitHub.app',
+          output_path: '/Users/you/GitHub.dmg',
+          built_at: '2026-06-30T13:00:00Z',
+        },
+      ],
+    });
+
+    addOrUpdateEntry(registry, updated);
+
+    expect(registry.entries[0].targets).toHaveLength(2);
+    expect(registry.entries[0].targets[1].platform).toBe('darwin');
+  });
+
+  it('updates an existing target instead of duplicating it', () => {
+    const registry: PakeRegistry = { entries: [createEntry()] };
+    const updated = createEntry({
+      targets: [
+        {
+          platform: 'linux',
+          target: 'deb',
+          output_path: '/home/you/GitHub-v2.deb',
+          built_at: '2026-06-30T13:00:00Z',
+        },
+      ],
+    });
+
+    addOrUpdateEntry(registry, updated);
+
+    expect(registry.entries[0].targets).toHaveLength(1);
+    expect(registry.entries[0].targets[0].output_path).toBe('/home/you/GitHub-v2.deb');
+    expect(registry.entries[0].targets[0].built_at).toBe('2026-06-30T13:00:00Z');
+  });
+
+  it('updates last_build_at while preserving created_at on upsert', () => {
+    const registry: PakeRegistry = {
+      entries: [createEntry({ created_at: '2026-06-30T10:00:00Z' })],
+    };
+    const updated = createEntry({ last_build_at: '2026-06-30T14:00:00Z' });
+
+    addOrUpdateEntry(registry, updated);
+
+    expect(registry.entries[0].created_at).toBe('2026-06-30T10:00:00Z');
+    expect(registry.entries[0].last_build_at).toBe('2026-06-30T14:00:00Z');
+  });
+
+  it('removes an entry by id', () => {
+    const entry = createEntry({ id: 'abc123' });
+    const registry: PakeRegistry = { entries: [entry] };
+
+    removeEntry(registry, 'abc123');
+
+    expect(registry.entries).toHaveLength(0);
+  });
+
+  it('generates a stable 12-character hex id from url and name', () => {
+    const id1 = generateEntryId('https://github.com', 'GitHub');
+    const id2 = generateEntryId('https://github.com', 'GitHub');
+
+    expect(id1).toBe(id2);
+    expect(id1).toHaveLength(12);
+    expect(/^[0-9a-f]{12}$/.test(id1)).toBe(true);
+  });
+
+  it('generates ids matching sha256(url + name) sliced to 12 hex chars', () => {
+    const expected = crypto
+      .createHash('sha256')
+      .update('https://github.comGitHub')
+      .digest('hex')
+      .slice(0, 12);
+
+    expect(generateEntryId('https://github.com', 'GitHub')).toBe(expected);
+  });
+});

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -19,6 +19,7 @@ describe('registry', () => {
   const tempFiles: string[] = [];
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await Promise.all(tempFiles.splice(0).map((file) => fsExtra.remove(file)));
   });
 
@@ -90,7 +91,6 @@ describe('registry', () => {
   it('writes registry atomically via temp file and rename', async () => {
     const registryPath = await tempRegistryPath();
     const registryDir = path.dirname(registryPath);
-    const tmpPath = path.join(registryDir, 'history.json.tmp');
     const registry: PakeRegistry = { entries: [createEntry()] };
 
     const ensureDirSpy = vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
@@ -99,7 +99,11 @@ describe('registry', () => {
 
     await writeRegistry(registryPath, registry);
 
+    const tmpPath = writeFileSpy.mock.calls[0][0] as string;
+
     expect(ensureDirSpy).toHaveBeenCalledWith(registryDir);
+    expect(tmpPath).toMatch(/history\.json\.tmp-/);
+    expect(tmpPath.startsWith(registryDir)).toBe(true);
     expect(writeFileSpy).toHaveBeenCalledWith(
       tmpPath,
       `${JSON.stringify(registry, null, 2)}\n`,
@@ -109,17 +113,59 @@ describe('registry', () => {
 
   it('removes temp file when atomic rename fails', async () => {
     const registryPath = await tempRegistryPath();
-    const registryDir = path.dirname(registryPath);
-    const tmpPath = path.join(registryDir, 'history.json.tmp');
     const registry: PakeRegistry = { entries: [createEntry()] };
 
     vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
-    vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+    const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
     vi.spyOn(fsExtra, 'rename').mockRejectedValue(new Error('rename failed'));
     const removeSpy = vi.spyOn(fsExtra, 'remove').mockResolvedValue(undefined);
 
     await expect(writeRegistry(registryPath, registry)).rejects.toThrow('rename failed');
+
+    const tmpPath = writeFileSpy.mock.calls[0][0] as string;
     expect(removeSpy).toHaveBeenCalledWith(tmpPath);
+  });
+
+  it('uses a unique temp file name for each writeRegistry call', async () => {
+    const registryPath = await tempRegistryPath();
+    const registry: PakeRegistry = { entries: [createEntry()] };
+
+    vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
+    vi.spyOn(fsExtra, 'rename').mockResolvedValue(undefined);
+    const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+
+    await writeRegistry(registryPath, registry);
+    await writeRegistry(registryPath, registry);
+
+    expect(writeFileSpy).toHaveBeenCalledTimes(2);
+    const firstTmpPath = writeFileSpy.mock.calls[0][0] as string;
+    const secondTmpPath = writeFileSpy.mock.calls[1][0] as string;
+
+    expect(firstTmpPath).not.toBe(secondTmpPath);
+    expect(firstTmpPath).toMatch(/history\.json\.tmp-/);
+    expect(secondTmpPath).toMatch(/history\.json\.tmp-/);
+  });
+
+  it('includes the process pid in the temp file name', async () => {
+    const originalPid = process.pid;
+    const testPid = 12345;
+    Object.defineProperty(process, 'pid', { value: testPid });
+
+    try {
+      const registryPath = await tempRegistryPath();
+      const registry: PakeRegistry = { entries: [createEntry()] };
+
+      vi.spyOn(fsExtra, 'ensureDir').mockResolvedValue(undefined);
+      vi.spyOn(fsExtra, 'rename').mockResolvedValue(undefined);
+      const writeFileSpy = vi.spyOn(fsExtra, 'writeFile').mockResolvedValue(undefined);
+
+      await writeRegistry(registryPath, registry);
+
+      const tmpPath = writeFileSpy.mock.calls[0][0] as string;
+      expect(tmpPath).toContain(`history.json.tmp-${testPid}-`);
+    } finally {
+      Object.defineProperty(process, 'pid', { value: originalPid });
+    }
   });
 
   it('finds an entry by exact name', () => {

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -223,13 +223,20 @@ describe('registry', () => {
     expect(/^[0-9a-f]{12}$/.test(id1)).toBe(true);
   });
 
-  it('generates ids matching sha256(url + name) sliced to 12 hex chars', () => {
+  it('generates ids matching sha256(url::name) sliced to 12 hex chars', () => {
     const expected = crypto
       .createHash('sha256')
-      .update('https://github.comGitHub')
+      .update('https://github.com::GitHub')
       .digest('hex')
       .slice(0, 12);
 
     expect(generateEntryId('https://github.com', 'GitHub')).toBe(expected);
+  });
+
+  it('avoids collisions between different url/name pairs', () => {
+    const id1 = generateEntryId('https://a.com', 'bc');
+    const id2 = generateEntryId('https://a.comb', 'c');
+
+    expect(id1).not.toBe(id2);
   });
 });

--- a/tests/unit/uninstall-remover-darwin.test.ts
+++ b/tests/unit/uninstall-remover-darwin.test.ts
@@ -102,6 +102,27 @@ describe('removeDarwinBinary', () => {
       '/Users/you/GitHub.dmg',
     );
   });
+
+  it('warns for both paths when install_path and output_path are missing', async () => {
+    mockedFsExtra.pathExists.mockResolvedValue(false);
+    const target = {
+      platform: 'darwin' as const,
+      format: 'dmg' as const,
+      install_path: '/Applications/GitHub.app',
+      output_path: '/Users/you/GitHub.dmg',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await expect(removeDarwinBinary(target)).resolves.toBeUndefined();
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('/Applications/GitHub.app'),
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('/Users/you/GitHub.dmg'),
+    );
+    expect(mockedFsExtra.remove).not.toHaveBeenCalled();
+  });
 });
 
 describe('removeDarwinData', () => {

--- a/tests/unit/uninstall-remover-darwin.test.ts
+++ b/tests/unit/uninstall-remover-darwin.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fsExtra from 'fs-extra';
+import { getAppDataPaths } from '@/utils/app-data-paths';
+import { removeDarwinBinary, removeDarwinData } from '@/commands/uninstall/remover-darwin';
+
+vi.mock('@/utils/app-data-paths', () => ({
+  getAppDataPaths: vi.fn(),
+}));
+
+vi.mock('fs-extra', () => ({
+  default: {
+    pathExists: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+const mockedFsExtra = fsExtra as unknown as {
+  pathExists: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+};
+
+const mockedGetAppDataPaths = getAppDataPaths as unknown as ReturnType<typeof vi.fn>;
+
+describe('removeDarwinBinary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedFsExtra.pathExists.mockResolvedValue(true);
+    mockedFsExtra.remove.mockResolvedValue(undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('removes install_path and output_path when both exist', async () => {
+    const target = {
+      platform: 'darwin' as const,
+      format: 'dmg' as const,
+      install_path: '/Applications/GitHub.app',
+      output_path: '/Users/you/GitHub.dmg',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeDarwinBinary(target);
+
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/Applications/GitHub.app');
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/Users/you/GitHub.dmg');
+  });
+
+  it('warns and continues when install_path is missing', async () => {
+    mockedFsExtra.pathExists.mockImplementation(async (p: string) =>
+      p !== '/Applications/GitHub.app' ? true : false,
+    );
+    const target = {
+      platform: 'darwin' as const,
+      format: 'dmg' as const,
+      install_path: '/Applications/GitHub.app',
+      output_path: '/Users/you/GitHub.dmg',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeDarwinBinary(target);
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('/Applications/GitHub.app'),
+    );
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/Users/you/GitHub.dmg');
+    expect(mockedFsExtra.remove).not.toHaveBeenCalledWith('/Applications/GitHub.app');
+  });
+
+  it('warns and continues when output_path is missing', async () => {
+    mockedFsExtra.pathExists.mockImplementation(async (p: string) =>
+      p !== '/Users/you/GitHub.dmg' ? true : false,
+    );
+    const target = {
+      platform: 'darwin' as const,
+      format: 'dmg' as const,
+      install_path: '/Applications/GitHub.app',
+      output_path: '/Users/you/GitHub.dmg',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeDarwinBinary(target);
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('/Users/you/GitHub.dmg'));
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/Applications/GitHub.app');
+    expect(mockedFsExtra.remove).not.toHaveBeenCalledWith('/Users/you/GitHub.dmg');
+  });
+});
+
+describe('removeDarwinData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedFsExtra.pathExists.mockResolvedValue(true);
+    mockedFsExtra.remove.mockResolvedValue(undefined);
+    mockedGetAppDataPaths.mockReturnValue({
+      config: '/Users/you/Library/Application Support/GitHub',
+      cache: '/Users/you/Library/Caches/GitHub',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('removes config and cache when both categories are selected', async () => {
+    await removeDarwinData('GitHub', { config: true, cache: true });
+
+    expect(mockedGetAppDataPaths).toHaveBeenCalledWith('GitHub');
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/Users/you/Library/Application Support/GitHub');
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/Users/you/Library/Caches/GitHub');
+  });
+
+  it('removes only cache when config is not selected', async () => {
+    await removeDarwinData('GitHub', { config: false, cache: true });
+
+    expect(mockedFsExtra.remove).not.toHaveBeenCalledWith(
+      '/Users/you/Library/Application Support/GitHub',
+    );
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/Users/you/Library/Caches/GitHub');
+  });
+});

--- a/tests/unit/uninstall-remover-darwin.test.ts
+++ b/tests/unit/uninstall-remover-darwin.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fsExtra from 'fs-extra';
 import { getAppDataPaths } from '@/utils/app-data-paths';
-import { removeDarwinBinary, removeDarwinData } from '@/commands/uninstall/remover-darwin';
+import {
+  removeDarwinBinary,
+  removeDarwinData,
+} from '@/commands/uninstall/remover-darwin';
 
 vi.mock('@/utils/app-data-paths', () => ({
   getAppDataPaths: vi.fn(),
@@ -19,7 +22,9 @@ const mockedFsExtra = fsExtra as unknown as {
   remove: ReturnType<typeof vi.fn>;
 };
 
-const mockedGetAppDataPaths = getAppDataPaths as unknown as ReturnType<typeof vi.fn>;
+const mockedGetAppDataPaths = getAppDataPaths as unknown as ReturnType<
+  typeof vi.fn
+>;
 
 describe('removeDarwinBinary', () => {
   beforeEach(() => {
@@ -44,7 +49,9 @@ describe('removeDarwinBinary', () => {
 
     await removeDarwinBinary(target);
 
-    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/Applications/GitHub.app');
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith(
+      '/Applications/GitHub.app',
+    );
     expect(mockedFsExtra.remove).toHaveBeenCalledWith('/Users/you/GitHub.dmg');
   });
 
@@ -66,7 +73,9 @@ describe('removeDarwinBinary', () => {
       expect.stringContaining('/Applications/GitHub.app'),
     );
     expect(mockedFsExtra.remove).toHaveBeenCalledWith('/Users/you/GitHub.dmg');
-    expect(mockedFsExtra.remove).not.toHaveBeenCalledWith('/Applications/GitHub.app');
+    expect(mockedFsExtra.remove).not.toHaveBeenCalledWith(
+      '/Applications/GitHub.app',
+    );
   });
 
   it('warns and continues when output_path is missing', async () => {
@@ -83,9 +92,15 @@ describe('removeDarwinBinary', () => {
 
     await removeDarwinBinary(target);
 
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('/Users/you/GitHub.dmg'));
-    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/Applications/GitHub.app');
-    expect(mockedFsExtra.remove).not.toHaveBeenCalledWith('/Users/you/GitHub.dmg');
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('/Users/you/GitHub.dmg'),
+    );
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith(
+      '/Applications/GitHub.app',
+    );
+    expect(mockedFsExtra.remove).not.toHaveBeenCalledWith(
+      '/Users/you/GitHub.dmg',
+    );
   });
 });
 
@@ -108,8 +123,12 @@ describe('removeDarwinData', () => {
     await removeDarwinData('GitHub', { config: true, cache: true });
 
     expect(mockedGetAppDataPaths).toHaveBeenCalledWith('GitHub');
-    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/Users/you/Library/Application Support/GitHub');
-    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/Users/you/Library/Caches/GitHub');
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith(
+      '/Users/you/Library/Application Support/GitHub',
+    );
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith(
+      '/Users/you/Library/Caches/GitHub',
+    );
   });
 
   it('removes only cache when config is not selected', async () => {
@@ -118,6 +137,8 @@ describe('removeDarwinData', () => {
     expect(mockedFsExtra.remove).not.toHaveBeenCalledWith(
       '/Users/you/Library/Application Support/GitHub',
     );
-    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/Users/you/Library/Caches/GitHub');
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith(
+      '/Users/you/Library/Caches/GitHub',
+    );
   });
 });

--- a/tests/unit/uninstall-remover-linux.test.ts
+++ b/tests/unit/uninstall-remover-linux.test.ts
@@ -65,9 +65,7 @@ describe('removeLinuxBinary', () => {
 
     await removeLinuxBinary('GitHub', target);
 
-    expect(mockedShellExec).toHaveBeenCalledWith(
-      'sudo dpkg --remove pake-github',
-    );
+    expect(mockedShellExec).toHaveBeenCalledWith('sudo dpkg --remove github');
   });
 
   it('matches builder package name for names with dots', async () => {
@@ -81,7 +79,7 @@ describe('removeLinuxBinary', () => {
     await removeLinuxBinary('My.App', target);
 
     expect(mockedShellExec).toHaveBeenCalledWith(
-      `sudo dpkg --remove pake-${generateLinuxPackageName('My.App')}`,
+      `sudo dpkg --remove ${generateLinuxPackageName('My.App')}`,
     );
   });
 
@@ -96,7 +94,7 @@ describe('removeLinuxBinary', () => {
     await removeLinuxBinary('我的应用', target);
 
     expect(mockedShellExec).toHaveBeenCalledWith(
-      `sudo dpkg --remove pake-${generateLinuxPackageName('我的应用')}`,
+      `sudo dpkg --remove ${generateLinuxPackageName('我的应用')}`,
     );
   });
 
@@ -110,9 +108,7 @@ describe('removeLinuxBinary', () => {
 
     await removeLinuxBinary('GitHub', target);
 
-    expect(mockedShellExec).toHaveBeenCalledWith(
-      'sudo rpm --erase pake-github',
-    );
+    expect(mockedShellExec).toHaveBeenCalledWith('sudo rpm --erase github');
   });
 
   it('aborts when dpkg removal fails', async () => {
@@ -155,7 +151,7 @@ describe('removeLinuxBinary', () => {
 
     await removeLinuxBinary('GitHub', target);
 
-    expect(mockedShellExec).toHaveBeenCalledWith('sudo pacman -R pake-github');
+    expect(mockedShellExec).toHaveBeenCalledWith('sudo pacman -R github');
   });
 
   it('warns and skips for zst format when pacman is missing', async () => {

--- a/tests/unit/uninstall-remover-linux.test.ts
+++ b/tests/unit/uninstall-remover-linux.test.ts
@@ -35,7 +35,9 @@ const mockedFsExtra = fsExtra as unknown as {
 
 const mockedExecSync = execSync as unknown as ReturnType<typeof vi.fn>;
 const mockedShellExec = shellExec as unknown as ReturnType<typeof vi.fn>;
-const mockedGetAppDataPaths = getAppDataPaths as unknown as ReturnType<typeof vi.fn>;
+const mockedGetAppDataPaths = getAppDataPaths as unknown as ReturnType<
+  typeof vi.fn
+>;
 
 describe('normalizedPackageName', () => {
   it('lowercases and prefixes with pake-', () => {
@@ -73,7 +75,9 @@ describe('removeLinuxBinary', () => {
 
     await removeLinuxBinary('GitHub', target);
 
-    expect(mockedShellExec).toHaveBeenCalledWith('sudo dpkg --remove pake-github');
+    expect(mockedShellExec).toHaveBeenCalledWith(
+      'sudo dpkg --remove pake-github',
+    );
   });
 
   it('invokes rpm for rpm format', async () => {
@@ -86,7 +90,9 @@ describe('removeLinuxBinary', () => {
 
     await removeLinuxBinary('GitHub', target);
 
-    expect(mockedShellExec).toHaveBeenCalledWith('sudo rpm --erase pake-github');
+    expect(mockedShellExec).toHaveBeenCalledWith(
+      'sudo rpm --erase pake-github',
+    );
   });
 
   it('invokes pacman for zst format when pacman exists', async () => {
@@ -133,7 +139,9 @@ describe('removeLinuxBinary', () => {
 
     await removeLinuxBinary('GitHub', target);
 
-    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/home/you/GitHub.AppImage');
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith(
+      '/home/you/GitHub.AppImage',
+    );
   });
 
   it('warns and continues when appimage output_path is missing', async () => {
@@ -162,7 +170,9 @@ describe('removeLinuxBinary', () => {
       built_at: '2024-01-01T00:00:00Z',
     };
 
-    await expect(removeLinuxBinary('GitHub', target)).rejects.toThrow('permission denied');
+    await expect(removeLinuxBinary('GitHub', target)).rejects.toThrow(
+      'permission denied',
+    );
     expect(console.warn).toHaveBeenCalled();
   });
 });
@@ -185,14 +195,22 @@ describe('removeLinuxData', () => {
   it('removes config and cache when both selected', async () => {
     await removeLinuxData('GitHub', { config: true, cache: true });
 
-    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/home/you/.config/GitHub');
-    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/home/you/.cache/GitHub');
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith(
+      '/home/you/.config/GitHub',
+    );
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith(
+      '/home/you/.cache/GitHub',
+    );
   });
 
   it('removes only cache when config is not selected', async () => {
     await removeLinuxData('GitHub', { config: false, cache: true });
 
-    expect(mockedFsExtra.remove).not.toHaveBeenCalledWith('/home/you/.config/GitHub');
-    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/home/you/.cache/GitHub');
+    expect(mockedFsExtra.remove).not.toHaveBeenCalledWith(
+      '/home/you/.config/GitHub',
+    );
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith(
+      '/home/you/.cache/GitHub',
+    );
   });
 });

--- a/tests/unit/uninstall-remover-linux.test.ts
+++ b/tests/unit/uninstall-remover-linux.test.ts
@@ -115,6 +115,32 @@ describe('removeLinuxBinary', () => {
     );
   });
 
+  it('aborts when dpkg removal fails', async () => {
+    const error = new Error('dpkg failed');
+    mockedShellExec.mockRejectedValue(error);
+    const target = {
+      platform: 'linux' as const,
+      format: 'deb' as const,
+      output_path: '/home/you/pake-github.deb',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await expect(removeLinuxBinary('GitHub', target)).rejects.toBe(error);
+  });
+
+  it('aborts when rpm removal fails', async () => {
+    const error = new Error('rpm failed');
+    mockedShellExec.mockRejectedValue(error);
+    const target = {
+      platform: 'linux' as const,
+      format: 'rpm' as const,
+      output_path: '/home/you/pake-github.rpm',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await expect(removeLinuxBinary('GitHub', target)).rejects.toBe(error);
+  });
+
   it('invokes pacman for zst format when pacman exists', async () => {
     mockedExecSync.mockImplementation((cmd: string) => {
       if (cmd === 'command -v pacman >/dev/null 2>&1') return '';
@@ -147,6 +173,23 @@ describe('removeLinuxBinary', () => {
 
     expect(console.warn).toHaveBeenCalled();
     expect(mockedShellExec).not.toHaveBeenCalled();
+  });
+
+  it('aborts when pacman removal fails for zst format', async () => {
+    const error = new Error('pacman failed');
+    mockedShellExec.mockRejectedValue(error);
+    mockedExecSync.mockImplementation((cmd: string) => {
+      if (cmd === 'command -v pacman >/dev/null 2>&1') return '';
+      throw new Error('command not found');
+    });
+    const target = {
+      platform: 'linux' as const,
+      format: 'zst' as const,
+      output_path: '/home/you/pake-github.zst',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await expect(removeLinuxBinary('GitHub', target)).rejects.toBe(error);
   });
 
   it('removes output_path for appimage format', async () => {

--- a/tests/unit/uninstall-remover-linux.test.ts
+++ b/tests/unit/uninstall-remover-linux.test.ts
@@ -3,8 +3,8 @@ import fsExtra from 'fs-extra';
 import { execSync } from 'child_process';
 import { getAppDataPaths } from '@/utils/app-data-paths';
 import { shellExec } from '@/utils/shell';
+import { generateLinuxPackageName } from '@/utils/name';
 import {
-  normalizedPackageName,
   removeLinuxBinary,
   removeLinuxData,
 } from '@/commands/uninstall/remover-linux';
@@ -39,16 +39,6 @@ const mockedGetAppDataPaths = getAppDataPaths as unknown as ReturnType<
   typeof vi.fn
 >;
 
-describe('normalizedPackageName', () => {
-  it('lowercases and prefixes with pake-', () => {
-    expect(normalizedPackageName('GitHub')).toBe('pake-github');
-  });
-
-  it('replaces spaces and special chars with hyphens', () => {
-    expect(normalizedPackageName('My App!')).toBe('pake-my-app');
-  });
-});
-
 describe('removeLinuxBinary', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -77,6 +67,36 @@ describe('removeLinuxBinary', () => {
 
     expect(mockedShellExec).toHaveBeenCalledWith(
       'sudo dpkg --remove pake-github',
+    );
+  });
+
+  it('matches builder package name for names with dots', async () => {
+    const target = {
+      platform: 'linux' as const,
+      format: 'deb' as const,
+      output_path: '/home/you/pake-my-app.deb',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeLinuxBinary('My.App', target);
+
+    expect(mockedShellExec).toHaveBeenCalledWith(
+      `sudo dpkg --remove pake-${generateLinuxPackageName('My.App')}`,
+    );
+  });
+
+  it('preserves CJK characters in package name to match builder output', async () => {
+    const target = {
+      platform: 'linux' as const,
+      format: 'deb' as const,
+      output_path: '/home/you/pake-我的应用.deb',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeLinuxBinary('我的应用', target);
+
+    expect(mockedShellExec).toHaveBeenCalledWith(
+      `sudo dpkg --remove pake-${generateLinuxPackageName('我的应用')}`,
     );
   });
 

--- a/tests/unit/uninstall-remover-linux.test.ts
+++ b/tests/unit/uninstall-remover-linux.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fsExtra from 'fs-extra';
+import { execSync } from 'child_process';
+import { getAppDataPaths } from '@/utils/app-data-paths';
+import { shellExec } from '@/utils/shell';
+import {
+  normalizedPackageName,
+  removeLinuxBinary,
+  removeLinuxData,
+} from '@/commands/uninstall/remover-linux';
+
+vi.mock('@/utils/app-data-paths', () => ({
+  getAppDataPaths: vi.fn(),
+}));
+
+vi.mock('fs-extra', () => ({
+  default: {
+    pathExists: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils/shell', () => ({
+  shellExec: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+const mockedFsExtra = fsExtra as unknown as {
+  pathExists: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+};
+
+const mockedExecSync = execSync as unknown as ReturnType<typeof vi.fn>;
+const mockedShellExec = shellExec as unknown as ReturnType<typeof vi.fn>;
+const mockedGetAppDataPaths = getAppDataPaths as unknown as ReturnType<typeof vi.fn>;
+
+describe('normalizedPackageName', () => {
+  it('lowercases and prefixes with pake-', () => {
+    expect(normalizedPackageName('GitHub')).toBe('pake-github');
+  });
+
+  it('replaces spaces and special chars with hyphens', () => {
+    expect(normalizedPackageName('My App!')).toBe('pake-my-app');
+  });
+});
+
+describe('removeLinuxBinary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedFsExtra.pathExists.mockResolvedValue(true);
+    mockedFsExtra.remove.mockResolvedValue(undefined);
+    mockedShellExec.mockResolvedValue(0);
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('command not found');
+    });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('invokes dpkg for deb format', async () => {
+    const target = {
+      platform: 'linux' as const,
+      format: 'deb' as const,
+      output_path: '/home/you/pake-github.deb',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeLinuxBinary('GitHub', target);
+
+    expect(mockedShellExec).toHaveBeenCalledWith('sudo dpkg --remove pake-github');
+  });
+
+  it('invokes rpm for rpm format', async () => {
+    const target = {
+      platform: 'linux' as const,
+      format: 'rpm' as const,
+      output_path: '/home/you/pake-github.rpm',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeLinuxBinary('GitHub', target);
+
+    expect(mockedShellExec).toHaveBeenCalledWith('sudo rpm --erase pake-github');
+  });
+
+  it('invokes pacman for zst format when pacman exists', async () => {
+    mockedExecSync.mockImplementation((cmd: string) => {
+      if (cmd === 'which pacman') return '/usr/bin/pacman';
+      throw new Error('command not found');
+    });
+    const target = {
+      platform: 'linux' as const,
+      format: 'zst' as const,
+      output_path: '/home/you/pake-github.zst',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeLinuxBinary('GitHub', target);
+
+    expect(mockedShellExec).toHaveBeenCalledWith('sudo pacman -R pake-github');
+  });
+
+  it('warns and skips for zst format when pacman is missing', async () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('command not found');
+    });
+    const target = {
+      platform: 'linux' as const,
+      format: 'zst' as const,
+      output_path: '/home/you/pake-github.zst',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeLinuxBinary('GitHub', target);
+
+    expect(console.warn).toHaveBeenCalled();
+    expect(mockedShellExec).not.toHaveBeenCalled();
+  });
+
+  it('removes output_path for appimage format', async () => {
+    const target = {
+      platform: 'linux' as const,
+      format: 'appimage' as const,
+      output_path: '/home/you/GitHub.AppImage',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeLinuxBinary('GitHub', target);
+
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/home/you/GitHub.AppImage');
+  });
+
+  it('warns and continues when appimage output_path is missing', async () => {
+    mockedFsExtra.pathExists.mockResolvedValue(false);
+    const target = {
+      platform: 'linux' as const,
+      format: 'appimage' as const,
+      output_path: '/home/you/GitHub.AppImage',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeLinuxBinary('GitHub', target);
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('/home/you/GitHub.AppImage'),
+    );
+    expect(mockedFsExtra.remove).not.toHaveBeenCalled();
+  });
+
+  it('warns per-path but surfaces permission error to handler', async () => {
+    mockedFsExtra.remove.mockRejectedValue(new Error('permission denied'));
+    const target = {
+      platform: 'linux' as const,
+      format: 'raw' as const,
+      output_path: '/home/you/pake-github',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await expect(removeLinuxBinary('GitHub', target)).rejects.toThrow('permission denied');
+    expect(console.warn).toHaveBeenCalled();
+  });
+});
+
+describe('removeLinuxData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedFsExtra.pathExists.mockResolvedValue(true);
+    mockedFsExtra.remove.mockResolvedValue(undefined);
+    mockedGetAppDataPaths.mockReturnValue({
+      config: '/home/you/.config/GitHub',
+      cache: '/home/you/.cache/GitHub',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('removes config and cache when both selected', async () => {
+    await removeLinuxData('GitHub', { config: true, cache: true });
+
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/home/you/.config/GitHub');
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/home/you/.cache/GitHub');
+  });
+
+  it('removes only cache when config is not selected', async () => {
+    await removeLinuxData('GitHub', { config: false, cache: true });
+
+    expect(mockedFsExtra.remove).not.toHaveBeenCalledWith('/home/you/.config/GitHub');
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith('/home/you/.cache/GitHub');
+  });
+});

--- a/tests/unit/uninstall-remover-linux.test.ts
+++ b/tests/unit/uninstall-remover-linux.test.ts
@@ -117,7 +117,7 @@ describe('removeLinuxBinary', () => {
 
   it('invokes pacman for zst format when pacman exists', async () => {
     mockedExecSync.mockImplementation((cmd: string) => {
-      if (cmd === 'which pacman') return '/usr/bin/pacman';
+      if (cmd === 'command -v pacman >/dev/null 2>&1') return '';
       throw new Error('command not found');
     });
     const target = {

--- a/tests/unit/uninstall-remover-windows.test.ts
+++ b/tests/unit/uninstall-remover-windows.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fsExtra from 'fs-extra';
+import { execSync } from 'child_process';
+import { getAppDataPaths } from '@/utils/app-data-paths';
+import { shellExec } from '@/utils/shell';
+import {
+  lookupWindowsProductCode,
+  removeWindowsBinary,
+  removeWindowsData,
+} from '@/commands/uninstall/remover-windows';
+
+vi.mock('@/utils/app-data-paths', () => ({
+  getAppDataPaths: vi.fn(),
+}));
+
+vi.mock('fs-extra', () => ({
+  default: {
+    pathExists: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils/shell', () => ({
+  shellExec: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+const mockedFsExtra = fsExtra as unknown as {
+  pathExists: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+};
+
+const mockedExecSync = execSync as unknown as ReturnType<typeof vi.fn>;
+const mockedShellExec = shellExec as unknown as ReturnType<typeof vi.fn>;
+const mockedGetAppDataPaths = getAppDataPaths as unknown as ReturnType<typeof vi.fn>;
+
+describe('lookupWindowsProductCode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns ProductCode when DisplayName matches', () => {
+    mockedExecSync.mockReturnValue(
+      'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{12345678-1234-1234-1234-123456789012}\n    DisplayName    REG_SZ    GitHub\n',
+    );
+
+    const result = lookupWindowsProductCode('GitHub');
+
+    expect(result).toBe('{12345678-1234-1234-1234-123456789012}');
+  });
+
+  it('returns undefined when no DisplayName matches', () => {
+    mockedExecSync.mockReturnValue(
+      'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{12345678-1234-1234-1234-123456789012}\n    DisplayName    REG_SZ    OtherApp\n',
+    );
+
+    const result = lookupWindowsProductCode('GitHub');
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('removeWindowsBinary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedFsExtra.pathExists.mockResolvedValue(true);
+    mockedFsExtra.remove.mockResolvedValue(undefined);
+    mockedShellExec.mockResolvedValue(0);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('invokes msiexec when ProductCode is found', async () => {
+    mockedExecSync.mockReturnValue(
+      'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{12345678-1234-1234-1234-123456789012}\n    DisplayName    REG_SZ    GitHub\n',
+    );
+    const target = {
+      platform: 'windows' as const,
+      format: 'msi' as const,
+      output_path: 'C:\\Users\\you\\GitHub.msi',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeWindowsBinary('GitHub', target);
+
+    expect(mockedShellExec).toHaveBeenCalledWith(
+      'msiexec /x {12345678-1234-1234-1234-123456789012} /qn /norestart',
+    );
+    expect(mockedFsExtra.remove).not.toHaveBeenCalled();
+  });
+
+  it('removes output_path when ProductCode is not found', async () => {
+    mockedExecSync.mockReturnValue('');
+    const target = {
+      platform: 'windows' as const,
+      format: 'msi' as const,
+      output_path: 'C:\\Users\\you\\GitHub.msi',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeWindowsBinary('GitHub', target);
+
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith('C:\\Users\\you\\GitHub.msi');
+    expect(mockedShellExec).not.toHaveBeenCalled();
+  });
+
+  it('warns and continues when output_path is missing and no ProductCode', async () => {
+    mockedExecSync.mockReturnValue('');
+    mockedFsExtra.pathExists.mockResolvedValue(false);
+    const target = {
+      platform: 'windows' as const,
+      format: 'msi' as const,
+      output_path: 'C:\\Users\\you\\GitHub.msi',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeWindowsBinary('GitHub', target);
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('C:\\Users\\you\\GitHub.msi'));
+    expect(mockedShellExec).not.toHaveBeenCalled();
+    expect(mockedFsExtra.remove).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeWindowsData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedFsExtra.pathExists.mockResolvedValue(true);
+    mockedFsExtra.remove.mockResolvedValue(undefined);
+    mockedGetAppDataPaths.mockReturnValue({
+      config: 'C:\\Users\\you\\AppData\\Roaming\\GitHub',
+      cache: 'C:\\Users\\you\\AppData\\Local\\GitHub',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('removes config and cache when both categories are selected', async () => {
+    await removeWindowsData('GitHub', { config: true, cache: true });
+
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith('C:\\Users\\you\\AppData\\Roaming\\GitHub');
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith('C:\\Users\\you\\AppData\\Local\\GitHub');
+  });
+});

--- a/tests/unit/uninstall-remover-windows.test.ts
+++ b/tests/unit/uninstall-remover-windows.test.ts
@@ -155,6 +155,64 @@ describe('removeWindowsBinary', () => {
     expect(mockedShellExec).not.toHaveBeenCalled();
     lookupSpy.mockRestore();
   });
+
+  it('falls back to file removal when registry query throws', async () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('permission denied');
+    });
+    const target = {
+      platform: 'windows' as const,
+      format: 'msi' as const,
+      output_path: 'C:\\Users\\you\\GitHub.msi',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeWindowsBinary('GitHub', target);
+
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith(
+      'C:\\Users\\you\\GitHub.msi',
+    );
+    expect(mockedShellExec).not.toHaveBeenCalled();
+  });
+
+  it('finds ProductCode in WOW6432Node when not in native hive', async () => {
+    mockedExecSync.mockImplementation((cmd: string) => {
+      if (!cmd.includes('WOW6432Node')) {
+        return 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{00000000-0000-0000-0000-000000000000}\n    DisplayName    REG_SZ    OtherApp\n';
+      }
+      return 'HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{12345678-1234-1234-1234-123456789012}\n    DisplayName    REG_SZ    GitHub\n';
+    });
+    const target = {
+      platform: 'windows' as const,
+      format: 'msi' as const,
+      output_path: 'C:\\Users\\you\\GitHub.msi',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeWindowsBinary('GitHub', target);
+
+    expect(mockedShellExec).toHaveBeenCalledWith(
+      'msiexec /x {12345678-1234-1234-1234-123456789012} /qn /norestart',
+    );
+  });
+
+  it('picks the first matching DisplayName deterministically', async () => {
+    mockedExecSync.mockReturnValue(
+      'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{11111111-1111-1111-1111-111111111111}\n    DisplayName    REG_SZ    GitHub\nHKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{22222222-2222-2222-2222-222222222222}\n    DisplayName    REG_SZ    GitHub\n',
+    );
+    const target = {
+      platform: 'windows' as const,
+      format: 'msi' as const,
+      output_path: 'C:\\Users\\you\\GitHub.msi',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeWindowsBinary('GitHub', target);
+
+    expect(mockedShellExec).toHaveBeenCalledWith(
+      'msiexec /x {11111111-1111-1111-1111-111111111111} /qn /norestart',
+    );
+  });
 });
 
 describe('removeWindowsData', () => {

--- a/tests/unit/uninstall-remover-windows.test.ts
+++ b/tests/unit/uninstall-remover-windows.test.ts
@@ -35,7 +35,9 @@ const mockedFsExtra = fsExtra as unknown as {
 
 const mockedExecSync = execSync as unknown as ReturnType<typeof vi.fn>;
 const mockedShellExec = shellExec as unknown as ReturnType<typeof vi.fn>;
-const mockedGetAppDataPaths = getAppDataPaths as unknown as ReturnType<typeof vi.fn>;
+const mockedGetAppDataPaths = getAppDataPaths as unknown as ReturnType<
+  typeof vi.fn
+>;
 
 describe('lookupWindowsProductCode', () => {
   beforeEach(() => {
@@ -106,7 +108,9 @@ describe('removeWindowsBinary', () => {
 
     await removeWindowsBinary('GitHub', target);
 
-    expect(mockedFsExtra.remove).toHaveBeenCalledWith('C:\\Users\\you\\GitHub.msi');
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith(
+      'C:\\Users\\you\\GitHub.msi',
+    );
     expect(mockedShellExec).not.toHaveBeenCalled();
   });
 
@@ -122,7 +126,9 @@ describe('removeWindowsBinary', () => {
 
     await removeWindowsBinary('GitHub', target);
 
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('C:\\Users\\you\\GitHub.msi'));
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('C:\\Users\\you\\GitHub.msi'),
+    );
     expect(mockedShellExec).not.toHaveBeenCalled();
     expect(mockedFsExtra.remove).not.toHaveBeenCalled();
   });
@@ -146,7 +152,11 @@ describe('removeWindowsData', () => {
   it('removes config and cache when both categories are selected', async () => {
     await removeWindowsData('GitHub', { config: true, cache: true });
 
-    expect(mockedFsExtra.remove).toHaveBeenCalledWith('C:\\Users\\you\\AppData\\Roaming\\GitHub');
-    expect(mockedFsExtra.remove).toHaveBeenCalledWith('C:\\Users\\you\\AppData\\Local\\GitHub');
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith(
+      'C:\\Users\\you\\AppData\\Roaming\\GitHub',
+    );
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith(
+      'C:\\Users\\you\\AppData\\Local\\GitHub',
+    );
   });
 });

--- a/tests/unit/uninstall-remover-windows.test.ts
+++ b/tests/unit/uninstall-remover-windows.test.ts
@@ -8,6 +8,7 @@ import {
   removeWindowsBinary,
   removeWindowsData,
 } from '@/commands/uninstall/remover-windows';
+import * as removerWindows from '@/commands/uninstall/remover-windows';
 
 vi.mock('@/utils/app-data-paths', () => ({
   getAppDataPaths: vi.fn(),
@@ -131,6 +132,28 @@ describe('removeWindowsBinary', () => {
     );
     expect(mockedShellExec).not.toHaveBeenCalled();
     expect(mockedFsExtra.remove).not.toHaveBeenCalled();
+  });
+
+  it('skips registry lookup for non-MSI formats and removes the file directly', async () => {
+    mockedExecSync.mockReturnValue(
+      'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{12345678-1234-1234-1234-123456789012}\n    DisplayName    REG_SZ    GitHub\n',
+    );
+    const lookupSpy = vi.spyOn(removerWindows, 'lookupWindowsProductCode');
+    const target = {
+      platform: 'windows' as const,
+      format: 'app' as const,
+      output_path: 'C:\\Users\\you\\GitHub.app',
+      built_at: '2024-01-01T00:00:00Z',
+    };
+
+    await removeWindowsBinary('GitHub', target);
+
+    expect(lookupSpy).not.toHaveBeenCalled();
+    expect(mockedFsExtra.remove).toHaveBeenCalledWith(
+      'C:\\Users\\you\\GitHub.app',
+    );
+    expect(mockedShellExec).not.toHaveBeenCalled();
+    lookupSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

Second PR in the `app-uninstall` feature chain (2 of 4). Implements the **Removers** phase: per-platform removal logic for macOS, Windows, and Linux, with safety properties verified by fresh review.

Resolves #1305 (part 2 of 4). Stacked on #1306.

## What's in this PR

- **`bin/commands/uninstall/remover-darwin.ts`** (new) — `removeDarwinBinary(target)` and `removeDarwinData(productName, categories)`. Uses `fsExtra.remove` for `install_path`, the local `.dmg`/`.app` artifact, and the macOS app data directories. Missing paths warn and continue.
- **`bin/commands/uninstall/remover-windows.ts`** (new) — `lookupWindowsProductCode(productName)`, `removeWindowsBinary(target)` (guarded by `target.format === 'msi'`), `removeWindowsData(productName, categories)`. Registry lookup is read-only; falls back to file removal when the `ProductCode` is not resolvable.
- **`bin/commands/uninstall/remover-linux.ts`** (new) — `removeLinuxBinary(target)` dispatching by `format` (deb / rpm / zst / appimage / raw), `removeLinuxData(productName, categories)`. Package-managed targets use `sudo` with `stdio: 'inherit'` so password prompts are visible. zst on non-Arch hosts skips with a warning instead of aborting.
- **3 new test files** — 14 + 13 + 21 = 48 new test cases, covering happy paths, missing paths, abort-on-failure for package managers, registry fallback, multi-hive lookup, CJK product names, and `command -v` portability.

## Safety properties verified

- **Correct package names on Linux** (post-review fix). The uninstaller targets the actual package name Tauri v2 writes into `.deb`/`.rpm` control files (`heck::AsKebabCase(product_name)`) and the zst `pkgname` (`generateLinuxPackageName(name)`), not the `pake-`-prefixed binary filename.
- **Windows `msiexec` only runs for MSI targets** (post-review fix). Non-MSI targets go straight to file removal.
- **Atomic write reuse from PR1** carries over (per-process temp file with `pid` + `Date.now()` + random suffix).
- **POSIX `command -v`** instead of `which` (post-review fix). `which` is not guaranteed to exist on minimal distros.
- **Abort on package-manager failure** (post-review test fix): deb/rpm/zst failures propagate as errors instead of being silently swallowed. The test suite now asserts this contract.
- **Missing paths warn and continue** for appimage/raw on Linux and for non-MSI paths on macOS.
- **msiexec uses `/qn /norestart`** (silent, default for CLI scripts).

## Review process

Two review passes by `review-readability` and `review-reliability` produced **2 CRITICAL/BLOCKER + 4 main WARNINGs** total. All have been fixed in 7 commits on top of the original 4 work-unit commits:

1. Reuse `generateLinuxPackageName` from `bin/utils/name.ts` (CRITICAL 1).
2. Drop the bogus `pake-` prefix on Linux package names (BLOCKER — caught in second pass).
3. Guard `removeWindowsBinary` by `target.format === 'msi'` (CRITICAL 2).
4. Replace `which` with `command -v` (WARNING 1).
5. Add abort-on-failure tests for deb/rpm/zst (WARNING 2).
6. Add JSDoc to all three remover modules (WARNING 3).
7. Add edge-case tests: macOS both-paths-missing, Windows registry fallback + WOW6432Node hive (WARNING 4).

## Follow-ups (deliberately deferred to keep this PR focused)

Documented in the SDD design and previous review notes; will land in later PRs or follow-ups:

- DRY violation: `removeDarwinData`, `removeLinuxData`, and `removeWindowsData` are byte-for-byte identical. Extract a shared `removeAppData(productName, categories)` helper in a future refactor.
- Logging consistency: the new modules use `console.warn(chalk.yellow(...))` instead of the project `logger.warn`. Switch to `logger.warn` (which already wraps `chalk.yellow`).
- `forbidOnly: true` in `vitest.config.ts` so a leftover `test.only` cannot silently pass CI.

## Next PRs

- **PR 3** — Handler + integration tests: `prompts` flow, orchestration, end-to-end uninstall handler.
- **PR 4** — Build integration + CLI surface: `BaseBuilder.recordBuildArtifact`, `LinuxBuilder` zst hook, `pake uninstall [name]` registration, `dist/cli.js` regeneration.

## Test commands

- `npx vitest run` — 276 tests pass.
- `pnpm run cli:build` — type check passes; `dist/cli.js` not modified by this PR.
- `npx prettier --check bin/commands/uninstall/remover-*.ts tests/unit/uninstall-remover-*.test.ts` — all pass.
