### PR TITLE
fix: fall back from malformed saved zoom

### DIFF
--- a/src-tauri/src/inject/event.js
+++ b/src-tauri/src/inject/event.js
@@ -15,25 +15,32 @@ function setZoom(zoom) {
   // CSS hacks. `transform: scale` and `html.style.zoom` break complex SPAs like
   // ChatGPT: the page shifts right on Windows and parts of the UI stop repainting
   // on macOS. Native zoom recalculates layout exactly like a browser does.
+  const zoomPercent = normalizeZoomPercent(zoom);
+  const normalizedZoom = `${zoomPercent}%`;
   const invoke = window.__TAURI__?.core?.invoke;
   if (invoke) {
-    invoke("set_zoom", { percent: parseFloat(zoom) }).catch(() => {});
+    invoke("set_zoom", { percent: zoomPercent }).catch(() => {});
   }
 
-  window.localStorage.setItem("htmlZoom", zoom);
+  window.localStorage.setItem("htmlZoom", normalizedZoom);
 }
 
 function zoomCommon(zoomChange) {
   const currentZoom = window.localStorage.getItem("htmlZoom") || "100%";
-  setZoom(zoomChange(currentZoom));
+  setZoom(zoomChange(normalizeZoomPercent(currentZoom)));
 }
 
 function zoomIn() {
-  zoomCommon((currentZoom) => `${Math.min(parseInt(currentZoom) + 10, 200)}%`);
+  zoomCommon((currentZoom) => `${Math.min(currentZoom + 10, 200)}%`);
 }
 
 function zoomOut() {
-  zoomCommon((currentZoom) => `${Math.max(parseInt(currentZoom) - 10, 30)}%`);
+  zoomCommon((currentZoom) => `${Math.max(currentZoom - 10, 30)}%`);
+}
+
+function normalizeZoomPercent(zoom) {
+  const parsed = parseFloat(zoom);
+  return Number.isFinite(parsed) ? parsed : 100;
 }
 
 let pasteAsPlainTextPending = false;

--- a/tests/unit/event-link-guard.test.js
+++ b/tests/unit/event-link-guard.test.js
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 function loadEventHelpers({
   withTauri = false,
   userAgent = "Mozilla/5.0",
+  initialZoom = null,
 } = {}) {
   const source = fs.readFileSync(
     path.join(process.cwd(), "src-tauri/src/inject/event.js"),
@@ -19,6 +20,10 @@ function loadEventHelpers({
   };
   const eventListeners = {};
   const elementsById = new Map();
+  const localStorageValues = new Map();
+  if (initialZoom !== null) {
+    localStorageValues.set("htmlZoom", initialZoom);
+  }
   const registerListener = (type, handler, options) => {
     eventListeners[type] = eventListeners[type] || [];
     eventListeners[type].push({ handler, options });
@@ -72,8 +77,10 @@ function loadEventHelpers({
         reload: () => {},
       },
       localStorage: {
-        getItem: () => null,
-        setItem: () => {},
+        getItem: (key) => localStorageValues.get(key) ?? null,
+        setItem: (key, value) => {
+          localStorageValues.set(key, value);
+        },
       },
       addEventListener: registerListener,
       dispatchEvent: () => {},
@@ -106,7 +113,7 @@ function loadEventHelpers({
   }
 
   runInNewContext(source, context);
-  return { ...context, eventListeners, invokeCalls };
+  return { ...context, eventListeners, invokeCalls, localStorageValues };
 }
 
 function runDomReady(context) {
@@ -139,6 +146,22 @@ function makeClickEvent(anchor) {
 }
 
 describe("event link guard", () => {
+  it("falls back from malformed saved zoom values", () => {
+    const context = loadEventHelpers({
+      withTauri: true,
+      initialZoom: "not-a-zoom",
+    });
+
+    context.zoomIn();
+    context.zoomOut();
+
+    expect(context.invokeCalls).toEqual([
+      ["set_zoom", { percent: 110 }],
+      ["set_zoom", { percent: 100 }],
+    ]);
+    expect(context.localStorageValues.get("htmlZoom")).toBe("100%");
+  });
+
   it("bypasses javascript pseudo-links", () => {
     const { shouldBypassPakeLinkHandling } = loadEventHelpers();
 


### PR DESCRIPTION
## Problem
The injected zoom shortcut handler reads the last saved zoom from `localStorage.htmlZoom`. If that value is malformed, `parseInt()` / `parseFloat()` can produce `NaN`, which then gets sent to the native `set_zoom` command and saved back as an invalid zoom value.

## Before / after
Before: a bad saved value such as `not-a-zoom` could make zoom shortcuts emit `NaN`.

After: saved zoom values are normalized through a small helper. Malformed values fall back to `100%`, then zoom shortcuts continue from there.

## Verification
- `pnpm exec vitest run tests/unit/event-link-guard.test.js`
- `pnpm exec prettier --check src-tauri/src/inject/event.js tests/unit/event-link-guard.test.js`
- `git diff --check`