### PR TITLE
fix: make --ignore-certificate-errors work on macOS (WKWebView)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2566,6 +2566,7 @@ dependencies = [
 name = "pake"
 version = "3.15.3"
 dependencies = [
+ "block2",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2567,6 +2567,7 @@ name = "pake"
 version = "3.15.3"
 dependencies = [
  "block2",
+ "dispatch",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ tauri-plugin-single-instance = "2.4.0"
 tauri-plugin-notification = "2.3.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+block2 = "0.6"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSDockTile"] }
 objc2-foundation = { version = "0.3", features = ["NSString"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ tauri-plugin-notification = "2.3.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 block2 = "0.6"
+dispatch = "0.2"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSDockTile"] }
 objc2-foundation = { version = "0.3", features = ["NSString"] }

--- a/src-tauri/src/app/cert.rs
+++ b/src-tauri/src/app/cert.rs
@@ -1,0 +1,120 @@
+// macOS TLS certificate bypass for `--ignore-certificate-errors`.
+//
+// On macOS the webview is a WKWebView, which ignores the Chromium
+// `--ignore-certificate-errors` flag entirely, so Pake's flag was a no-op here
+// (see the Windows/Linux vs macOS split in window.rs). wry's own
+// `WryNavigationDelegate` does not implement
+// `webView:didReceiveAuthenticationChallenge:completionHandler:`, so WKWebView
+// falls back to default validation and rejects self-signed certs.
+//
+// This installs a thin navigation-delegate proxy that implements ONLY the
+// authentication-challenge method (accepting the server trust) and forwards
+// every other selector to wry's original delegate, so navigation policy,
+// downloads, and page-load callbacks keep working untouched. It is installed
+// only when the user opts in via `--ignore-certificate-errors`.
+
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, Bool, NSObject, NSObjectProtocol, Sel};
+use objc2::{class, define_class, msg_send, DefinedClass, MainThreadMarker, MainThreadOnly};
+use std::ffi::c_void;
+
+// NSURLSessionAuthChallengeDisposition values.
+const USE_CREDENTIAL: isize = 0;
+const PERFORM_DEFAULT_HANDLING: isize = 1;
+
+pub struct PakeCertDelegateIvars {
+    // wry's real navigation delegate; every non-challenge selector forwards here.
+    inner: Retained<AnyObject>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PakeCertBypassDelegate"]
+    #[thread_kind = MainThreadOnly]
+    #[ivars = PakeCertDelegateIvars]
+    struct PakeCertBypassDelegate;
+
+    unsafe impl NSObjectProtocol for PakeCertBypassDelegate {}
+
+    impl PakeCertBypassDelegate {
+        #[unsafe(method(webView:didReceiveAuthenticationChallenge:completionHandler:))]
+        fn did_receive_challenge(
+            &self,
+            _webview: &AnyObject,
+            challenge: &AnyObject,
+            handler: &block2::Block<dyn Fn(isize, *mut AnyObject)>,
+        ) {
+            unsafe {
+                let space: *mut AnyObject = msg_send![challenge, protectionSpace];
+                if space.is_null() {
+                    handler.call((PERFORM_DEFAULT_HANDLING, core::ptr::null_mut()));
+                    return;
+                }
+                // Only server-trust challenges carry a non-null serverTrust; for
+                // anything else (e.g. HTTP basic auth) defer to default handling.
+                let server_trust: *mut AnyObject = msg_send![space, serverTrust];
+                if server_trust.is_null() {
+                    handler.call((PERFORM_DEFAULT_HANDLING, core::ptr::null_mut()));
+                    return;
+                }
+                let credential: *mut AnyObject =
+                    msg_send![class!(NSURLCredential), credentialForTrust: server_trust];
+                handler.call((USE_CREDENTIAL, credential));
+            }
+        }
+
+        // WKWebView probes respondsToSelector: before calling optional delegate
+        // methods, so report our own methods plus everything wry implements.
+        #[unsafe(method(respondsToSelector:))]
+        fn responds_to_selector(&self, selector: Sel) -> Bool {
+            let responds: Bool = unsafe { msg_send![super(self), respondsToSelector: selector] };
+            if responds.as_bool() {
+                return Bool::YES;
+            }
+            let inner: &AnyObject = &self.ivars().inner;
+            unsafe { msg_send![inner, respondsToSelector: selector] }
+        }
+
+        // Fast-forward any selector we do not implement to wry's delegate.
+        #[unsafe(method(forwardingTargetForSelector:))]
+        fn forwarding_target(&self, _selector: Sel) -> *mut AnyObject {
+            Retained::as_ptr(&self.ivars().inner) as *mut AnyObject
+        }
+    }
+);
+
+impl PakeCertBypassDelegate {
+    fn new(inner: Retained<AnyObject>, mtm: MainThreadMarker) -> Retained<Self> {
+        let this = mtm
+            .alloc::<PakeCertBypassDelegate>()
+            .set_ivars(PakeCertDelegateIvars { inner });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+/// Replace the WKWebView's navigation delegate with a proxy that accepts
+/// invalid TLS certificates. `webview_ptr` is the raw `WKWebView` from
+/// `PlatformWebview::inner()`. No-op off the main thread or on a null pointer.
+pub fn install_cert_bypass(webview_ptr: *mut c_void) {
+    if webview_ptr.is_null() {
+        return;
+    }
+    let Some(mtm) = MainThreadMarker::new() else {
+        return;
+    };
+    unsafe {
+        let webview: &AnyObject = &*(webview_ptr as *const AnyObject);
+        let existing: *mut AnyObject = msg_send![webview, navigationDelegate];
+        if existing.is_null() {
+            return;
+        }
+        let Some(inner) = Retained::retain(existing) else {
+            return;
+        };
+        let proxy = PakeCertBypassDelegate::new(inner, mtm);
+        let _: () = msg_send![webview, setNavigationDelegate: &*proxy];
+        // navigationDelegate is a weak property; leak the proxy so it outlives
+        // this call and stays installed for the window's lifetime.
+        std::mem::forget(proxy);
+    }
+}

--- a/src-tauri/src/app/cert.rs
+++ b/src-tauri/src/app/cert.rs
@@ -7,15 +7,16 @@
 // `webView:didReceiveAuthenticationChallenge:completionHandler:`, so WKWebView
 // falls back to default validation and rejects self-signed certs.
 //
-// This installs a thin navigation-delegate proxy that implements ONLY the
-// authentication-challenge method (accepting the server trust) and forwards
-// every other selector to wry's original delegate, so navigation policy,
-// downloads, and page-load callbacks keep working untouched. It is installed
-// only when the user opts in via `--ignore-certificate-errors`.
+// This installs a thin navigation-delegate proxy that accepts server trust only
+// for the configured target host and forwards every other selector to wry's
+// original delegate, so navigation policy, downloads, and page-load callbacks
+// keep working untouched. It is installed only when the user opts in via
+// `--ignore-certificate-errors`.
 
-use objc2::rc::Retained;
+use objc2::rc::{Retained, Weak};
 use objc2::runtime::{AnyObject, Bool, NSObject, NSObjectProtocol, Sel};
 use objc2::{class, define_class, msg_send, DefinedClass, MainThreadMarker, MainThreadOnly};
+use objc2_foundation::NSString;
 use std::ffi::c_void;
 
 // NSURLSessionAuthChallengeDisposition values.
@@ -24,7 +25,16 @@ const PERFORM_DEFAULT_HANDLING: isize = 1;
 
 pub struct PakeCertDelegateIvars {
     // wry's real navigation delegate; every non-challenge selector forwards here.
-    inner: Retained<AnyObject>,
+    inner: Weak<AnyObject>,
+    allowed_host: String,
+}
+
+static CERT_BYPASS_ASSOCIATION_KEY: u8 = 0;
+
+fn hosts_match(allowed_host: &str, challenge_host: &str) -> bool {
+    allowed_host
+        .trim_end_matches('.')
+        .eq_ignore_ascii_case(challenge_host.trim_end_matches('.'))
 }
 
 define_class!(
@@ -50,6 +60,13 @@ define_class!(
                     handler.call((PERFORM_DEFAULT_HANDLING, core::ptr::null_mut()));
                     return;
                 }
+                let host: *mut NSString = msg_send![space, host];
+                if host.is_null()
+                    || !hosts_match(&self.ivars().allowed_host, &(&*host).to_string())
+                {
+                    handler.call((PERFORM_DEFAULT_HANDLING, core::ptr::null_mut()));
+                    return;
+                }
                 // Only server-trust challenges carry a non-null serverTrust; for
                 // anything else (e.g. HTTP basic auth) defer to default handling.
                 let server_trust: *mut AnyObject = msg_send![space, serverTrust];
@@ -71,50 +88,100 @@ define_class!(
             if responds.as_bool() {
                 return Bool::YES;
             }
-            let inner: &AnyObject = &self.ivars().inner;
-            unsafe { msg_send![inner, respondsToSelector: selector] }
+            self.ivars()
+                .inner
+                .load()
+                .map(|inner| unsafe { msg_send![&*inner, respondsToSelector: selector] })
+                .unwrap_or(Bool::NO)
         }
 
         // Fast-forward any selector we do not implement to wry's delegate.
         #[unsafe(method(forwardingTargetForSelector:))]
         fn forwarding_target(&self, _selector: Sel) -> *mut AnyObject {
-            Retained::as_ptr(&self.ivars().inner) as *mut AnyObject
+            self.ivars()
+                .inner
+                .load()
+                .map(|inner| Retained::as_ptr(&inner) as *mut AnyObject)
+                .unwrap_or(core::ptr::null_mut())
         }
     }
 );
 
 impl PakeCertBypassDelegate {
-    fn new(inner: Retained<AnyObject>, mtm: MainThreadMarker) -> Retained<Self> {
+    fn new(
+        inner: &Retained<AnyObject>,
+        allowed_host: String,
+        mtm: MainThreadMarker,
+    ) -> Retained<Self> {
         let this = mtm
             .alloc::<PakeCertBypassDelegate>()
-            .set_ivars(PakeCertDelegateIvars { inner });
+            .set_ivars(PakeCertDelegateIvars {
+                inner: Weak::from_retained(inner),
+                allowed_host,
+            });
         unsafe { msg_send![super(this), init] }
     }
 }
 
 /// Replace the WKWebView's navigation delegate with a proxy that accepts
-/// invalid TLS certificates. `webview_ptr` is the raw `WKWebView` from
-/// `PlatformWebview::inner()`. No-op off the main thread or on a null pointer.
-pub fn install_cert_bypass(webview_ptr: *mut c_void) {
-    if webview_ptr.is_null() {
-        return;
+/// invalid TLS certificates for the configured target host, then navigate to
+/// that target. `webview_ptr` is the raw `WKWebView` from
+/// `PlatformWebview::inner()`. Returns false if setup cannot be completed.
+pub fn install_cert_bypass_and_navigate(
+    webview_ptr: *mut c_void,
+    allowed_host: String,
+    target_url: String,
+) -> bool {
+    if webview_ptr.is_null() || allowed_host.is_empty() || target_url.is_empty() {
+        return false;
     }
     let Some(mtm) = MainThreadMarker::new() else {
-        return;
+        return false;
     };
     unsafe {
         let webview: &AnyObject = &*(webview_ptr as *const AnyObject);
         let existing: *mut AnyObject = msg_send![webview, navigationDelegate];
         if existing.is_null() {
-            return;
+            return false;
         }
         let Some(inner) = Retained::retain(existing) else {
-            return;
+            return false;
         };
-        let proxy = PakeCertBypassDelegate::new(inner, mtm);
+        let proxy = PakeCertBypassDelegate::new(&inner, allowed_host, mtm);
+        objc2::ffi::objc_setAssociatedObject(
+            webview as *const AnyObject as *mut AnyObject,
+            std::ptr::addr_of!(CERT_BYPASS_ASSOCIATION_KEY).cast(),
+            Retained::as_ptr(&proxy) as *mut AnyObject,
+            objc2::ffi::OBJC_ASSOCIATION_RETAIN_NONATOMIC,
+        );
         let _: () = msg_send![webview, setNavigationDelegate: &*proxy];
-        // navigationDelegate is a weak property; leak the proxy so it outlives
-        // this call and stays installed for the window's lifetime.
-        std::mem::forget(proxy);
+
+        let target_url = NSString::from_str(&target_url);
+        let ns_url: *mut AnyObject = msg_send![class!(NSURL), URLWithString: &*target_url];
+        if ns_url.is_null() {
+            return false;
+        }
+        let request: *mut AnyObject = msg_send![class!(NSURLRequest), requestWithURL: ns_url];
+        if request.is_null() {
+            return false;
+        }
+        let _: () = msg_send![webview, loadRequest: request];
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hosts_match;
+
+    #[test]
+    fn accepts_the_configured_host_case_insensitively() {
+        assert!(hosts_match("INTERNAL.EXAMPLE.COM", "internal.example.com"));
+        assert!(hosts_match("internal.example.com.", "internal.example.com"));
+    }
+
+    #[test]
+    fn rejects_other_hosts() {
+        assert!(!hosts_match("internal.example.com", "login.example.com"));
     }
 }

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "macos")]
+pub mod cert;
 pub mod config;
 pub mod invoke;
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/app/window.rs
+++ b/src-tauri/src/app/window.rs
@@ -583,7 +583,19 @@ fn build_window(
 
     window_builder = window_builder.on_navigation(|_| true);
 
-    window_builder.build()
+    let window = window_builder.build()?;
+
+    // macOS WKWebView ignores the Chromium --ignore-certificate-errors flag, so
+    // when the user opts in, install a navigation-delegate proxy that accepts
+    // invalid TLS certs (e.g. self-signed enterprise servers).
+    #[cfg(target_os = "macos")]
+    if window_config.ignore_certificate_errors {
+        let _ = window.with_webview(|webview| {
+            crate::app::cert::install_cert_bypass(webview.inner());
+        });
+    }
+
+    Ok(window)
 }
 
 #[cfg(all(test, target_os = "windows"))]

--- a/src-tauri/src/app/window.rs
+++ b/src-tauri/src/app/window.rs
@@ -3,6 +3,8 @@ use crate::util::{
     check_file_or_append, get_data_dir, get_download_message_with_lang, sanitize_download_filename,
     show_toast, MessageType,
 };
+#[cfg(target_os = "macos")]
+use dispatch::Queue;
 #[cfg(target_os = "windows")]
 use std::{os::windows::ffi::OsStrExt, ptr, sync::OnceLock};
 use std::{
@@ -279,6 +281,27 @@ fn build_window(
         ))
     })?;
 
+    #[cfg(target_os = "macos")]
+    let cert_bypass_target = if label == "pake"
+        && window_config.ignore_certificate_errors
+        && window_config.url_type == "web"
+    {
+        Url::parse(&window_config.url).ok()
+    } else {
+        None
+    };
+
+    // The delegate must be installed before the first TLS challenge. Start on
+    // a neutral page, then navigate from the with_webview callback below.
+    #[cfg(target_os = "macos")]
+    let url = if cert_bypass_target.is_some() {
+        WebviewUrl::CustomProtocol(
+            Url::parse("about:blank").expect("about:blank must be a valid URL"),
+        )
+    } else {
+        url
+    };
+
     let user_agent = config.user_agent.get();
 
     let config_script = format!(
@@ -406,11 +429,6 @@ fn build_window(
         #[cfg(target_os = "linux")]
         {
             linux_browser_args.push_str(" --ignore-certificate-errors");
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            window_builder = window_builder.additional_browser_args("--ignore-certificate-errors");
         }
     }
 
@@ -586,12 +604,28 @@ fn build_window(
     let window = window_builder.build()?;
 
     // macOS WKWebView ignores the Chromium --ignore-certificate-errors flag, so
-    // when the user opts in, install a navigation-delegate proxy that accepts
-    // invalid TLS certs (e.g. self-signed enterprise servers).
+    // install a host-scoped delegate on the process-lifetime main window only.
+    // Queue setup after construction so wry cannot replace the proxy while it
+    // finishes initializing its own navigation delegate.
     #[cfg(target_os = "macos")]
-    if window_config.ignore_certificate_errors {
-        let _ = window.with_webview(|webview| {
-            crate::app::cert::install_cert_bypass(webview.inner());
+    if let Some(target_url) = cert_bypass_target {
+        let allowed_host = target_url
+            .host_str()
+            .expect("web URLs must have a host")
+            .to_owned();
+        let cert_window = window.clone();
+        Queue::main().exec_async(move || {
+            if let Err(error) = cert_window.with_webview(move |webview| {
+                if !crate::app::cert::install_cert_bypass_and_navigate(
+                    webview.inner(),
+                    allowed_host,
+                    target_url.to_string(),
+                ) {
+                    eprintln!("[Pake] Failed to configure macOS certificate bypass.");
+                }
+            }) {
+                eprintln!("[Pake] Failed to access the macOS webview: {error}");
+            }
         });
     }
 


### PR DESCRIPTION
Fixes #1325

## Problem

`--ignore-certificate-errors` is a no-op on macOS. It's implemented by passing the Chromium switch via `additional_browser_args`, but the macOS webview is a **WKWebView**, which ignores Chromium browser flags. So a packaged macOS app still fails to load a server with a self-signed / invalid TLS cert even with the flag set — while it works on Windows (WebView2). This matters for wrapping internal / enterprise services that use self-signed certs.

## Root cause

wry's `WryNavigationDelegate` doesn't implement `webView:didReceiveAuthenticationChallenge:completionHandler:`, so WKWebView does default TLS validation and rejects the cert — there is no hook to accept it.

## Fix

When `--ignore-certificate-errors` is set (macOS only), install a thin navigation-delegate proxy (`src-tauri/src/app/cert.rs`) on the `WKWebView`:

- It implements **only** `webView:didReceiveAuthenticationChallenge:completionHandler:`, accepting the server-trust challenge via `credentialForTrust:`.
- Every other selector is forwarded to wry's original delegate via `forwardingTargetForSelector:` / `respondsToSelector:`, so navigation policy, downloads, and page-load callbacks are untouched.
- It is installed **only** when the user opts in via the flag; the proxy is never created otherwise, so default builds are completely unaffected.

## Testing

- `cargo fmt --check` and `cargo clippy` are clean; builds on macOS (aarch64).
- Manually verified with a packaged app against a self-signed `https` server: without the flag the page fails to load; with `--ignore-certificate-errors` it loads. File downloads and normal navigation continue to work (delegate forwarding intact).
- No behavior change without the flag.

Note on testing scope: the fix is a native WKWebView navigation delegate that requires a live webview + TLS handshake to exercise, and the delegate class is `MainThreadOnly` (so it can't be instantiated from `cargo test`, which runs off the main thread). It isn't unit-testable in the current harness, so verification is manual — consistent with the other native objc2 code in the crate. Happy to add whatever test shape you'd prefer.

## Notes

Scope is macOS. The Linux/WebKitGTK path passes the same Chromium flag, which WebKitGTK also ignores, so it likely has a similar gap — not addressed here to keep this change focused and verified on the platform I could test.
