### PR TITLE
fix: make Go Home work on error pages and local-file apps

### DIFF
--- a/src-tauri/src/app/menu.rs
+++ b/src-tauri/src/app/menu.rs
@@ -1,5 +1,5 @@
 // Menu functionality is only used on macOS; the module is gated in app/mod.rs.
-use crate::app::window::open_additional_window_safe;
+use crate::app::window::{open_additional_window_safe, MultiWindowState};
 use tauri::menu::{AboutMetadata, Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::{AppHandle, Manager, Wry};
 use tauri_plugin_opener::OpenerExt;
@@ -224,6 +224,27 @@ fn help_menu(app: &AppHandle<Wry>, title: &str) -> tauri::Result<Submenu<Wry>> {
     Ok(help_menu)
 }
 
+// Resolve the app's real home URL from its window config. Split out from
+// `home_url` so the mapping can be unit-tested without an AppHandle.
+fn resolve_home_url(url_type: &str, url: &str) -> Option<tauri::Url> {
+    match url_type {
+        // A web app's configured url is already absolute.
+        "web" => tauri::Url::parse(url).ok(),
+        // A local-file app's url is only a basename; Tauri serves bundled assets
+        // from tauri://localhost on macOS (this menu is macOS-only). Resolving it
+        // against the currently loaded remote origin (as the old eval path did)
+        // would point at the wrong server.
+        "local" => tauri::Url::parse(&format!("tauri://localhost/{url}")).ok(),
+        _ => None,
+    }
+}
+
+fn home_url(app: &AppHandle) -> Option<tauri::Url> {
+    let state = app.try_state::<MultiWindowState>()?;
+    let window_config = state.pake_config.windows.first()?;
+    resolve_home_url(&window_config.url_type, &window_config.url)
+}
+
 pub fn handle_menu_click(app_handle: &AppHandle, id: &str) {
     match id {
         "new_window" => {
@@ -276,7 +297,17 @@ pub fn handle_menu_click(app_handle: &AppHandle, id: &str) {
         }
         "go_home" => {
             if let Some(window) = app_handle.get_webview_window("pake") {
-                let _ = window.eval("window.location.href = window.pakeConfig.url");
+                // Native navigation works even from a blank error page (where
+                // eval cannot run) and resolves local-file apps to the correct
+                // bundled asset instead of a path on the current origin.
+                match home_url(app_handle) {
+                    Some(url) => {
+                        let _ = window.navigate(url);
+                    }
+                    None => {
+                        let _ = window.eval("window.location.href = window.pakeConfig.url");
+                    }
+                }
             }
         }
         "copy_url" => {
@@ -318,5 +349,33 @@ pub fn handle_menu_click(app_handle: &AppHandle, id: &str) {
             }
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_home_url;
+
+    #[test]
+    fn web_url_passes_through_unchanged() {
+        assert_eq!(
+            resolve_home_url("web", "https://github.com").map(|u| u.to_string()),
+            Some("https://github.com/".to_string())
+        );
+    }
+
+    #[test]
+    fn local_basename_resolves_to_bundled_asset_url() {
+        // The fix: a local app's basename must become the bundled asset URL,
+        // not a path resolved against whatever origin is currently loaded.
+        assert_eq!(
+            resolve_home_url("local", "launcher.html").map(|u| u.to_string()),
+            Some("tauri://localhost/launcher.html".to_string())
+        );
+    }
+
+    #[test]
+    fn unknown_url_type_is_none() {
+        assert!(resolve_home_url("bogus", "whatever").is_none());
     }
 }


### PR DESCRIPTION
Fixes #1327

## Problem

**Navigation → Go Home** (⌘⇧H) fails in two cases:

1. **Blank / error page** — the handler runs `window.eval("window.location.href = window.pakeConfig.url")`, but a failed navigation shows a WKWebView error page with no page JS context, so `eval` does nothing. Go Home is dead exactly when you're stuck.
2. **Local-file apps** (`url_type: "local"`) — `pakeConfig.url` is only the basename, so it resolves against the currently loaded origin. After navigating to another site, Go Home targets `https://that-site/<basename>` (404) rather than the bundled home page.

## Fix

Resolve the real home URL from the window config and use the native `window.navigate()`:

- `web` → the configured absolute URL
- `local` → `tauri://localhost/<basename>` (the bundled asset; this menu is macOS-only)

Native navigation works even on an error page, and it targets the correct asset for local-file apps. Web apps benefit too — Go Home now works from a blank error page, which the `eval` path didn't.

The URL mapping is split into a pure `resolve_home_url(url_type, url)` and unit-tested:

- web URL passes through unchanged
- local basename → bundled asset URL
- unknown type → `None`

## Testing

- `cargo test` (macOS): the 3 new tests pass.
- `cargo fmt --check` and `cargo clippy` clean.
- Manually verified: from a blank error page, and after a local-file app has navigated to another origin, ⌘⇧H now returns to the bundled home page; the previous build did not.

## Scope

macOS only — the Navigation menu (and Go Home) is macOS-gated in Pake. The `window.navigate()` swap itself isn't unit-testable (it needs a live webview), so that half is manual-verified; the URL-mapping logic that the fix hinges on is covered by the unit tests.
