### PR TITLE
fix: avoid downloading GitHub release pages as documents

### DIFF
--- a/src-tauri/src/inject/event.js
+++ b/src-tauri/src/inject/event.js
@@ -437,7 +437,6 @@ const DOWNLOAD_PATH_PATTERNS = [
   "/files/",
   "/attachments/",
   "/assets/",
-  "/releases/",
   "/dist/",
 ];
 

--- a/tests/unit/event-link-guard.test.js
+++ b/tests/unit/event-link-guard.test.js
@@ -188,10 +188,7 @@ describe("event link guard", () => {
     runDomReady(context);
 
     const event = makeClickEvent(
-      makeAnchor(
-        "https://github.com/owner/repo/releases/tag/v1.28.3",
-        "_self",
-      ),
+      makeAnchor("https://github.com/owner/repo/releases/tag/v1.28.3", "_self"),
     );
     getClickGuard(context)(event);
 

--- a/tests/unit/event-link-guard.test.js
+++ b/tests/unit/event-link-guard.test.js
@@ -182,6 +182,54 @@ describe("event link guard", () => {
     );
   });
 
+  it("navigates GitHub release pages instead of downloading them as documents", () => {
+    const context = loadEventHelpers({ withTauri: true });
+    context.window.location.href = "https://github.com/owner/repo/releases";
+    runDomReady(context);
+
+    const event = makeClickEvent(
+      makeAnchor(
+        "https://github.com/owner/repo/releases/tag/v1.28.3",
+        "_self",
+      ),
+    );
+    getClickGuard(context)(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(context.invokeCalls).not.toContainEqual([
+      "download_file",
+      expect.anything(),
+    ]);
+  });
+
+  it("still downloads files linked from GitHub releases", () => {
+    const context = loadEventHelpers({ withTauri: true });
+    context.window.location.href = "https://github.com/owner/repo/releases";
+    runDomReady(context);
+
+    const event = makeClickEvent(
+      makeAnchor(
+        "https://github.com/owner/repo/releases/download/v1.28.3/app.dmg",
+        "_self",
+      ),
+    );
+    getClickGuard(context)(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopImmediatePropagation).toHaveBeenCalled();
+    expect(context.invokeCalls).toContainEqual([
+      "download_file",
+      {
+        params: {
+          url: "https://github.com/owner/repo/releases/download/v1.28.3/app.dmg",
+          filename: "app.dmg",
+          language: "en-US",
+        },
+      },
+    ]);
+  });
+
   it("navigates macOS auth URLs in the current window", () => {
     const { openAuthNavigation, window } = loadEventHelpers({
       userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_5)",


### PR DESCRIPTION
## Summary

- stop treating every URL under `/releases/` as a downloadable file
- keep normal GitHub release tag pages in the webview
- preserve downloads for actual release assets such as `/releases/download/.../app.dmg`

## Root cause

`DOWNLOAD_PATH_PATTERNS` included the broad `/releases/` fragment. Clicking a GitHub release page such as `/releases/tag/v1.28.3` therefore bypassed navigation and invoked Pake's file downloader. The downloader saved the release page HTML using the final URL segment, producing an extensionless `v1.28.3` document instead of opening the page where the DMG asset can be selected.

Actual GitHub release assets remain detectable through `/download/` and their file extensions, so the broad pattern is unnecessary.

## Validation

- reproduced with a regression test that fails on `main`
- `npx vitest run tests/unit/event-link-guard.test.js` (19 passed)
- `npx vitest run` (34 files, 306 tests passed)
- `pnpm run format:check`
- `pnpm run cli:build`
- `pnpm run build:debug` (macOS app and DMG bundled successfully)
