### PR TITLE
fix: support safe external URI schemes

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,7 +7,17 @@
     "urls": ["https://*.*"]
   },
   "permissions": [
-    "shell:allow-open",
+    "opener:default",
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [
+        { "url": "sms:*" },
+        { "url": "geo:*" },
+        { "url": "tencent://ntqq-open[?]*" },
+        { "url": "mqqapi://userprofile/friend_profile_card[?]*" },
+        { "url": "mqq://card/show_pslcard[?]*" }
+      ]
+    },
     "core:window:allow-theme",
     "core:window:allow-start-dragging",
     "core:window:allow-toggle-maximize",

--- a/src-tauri/src/inject/event.js
+++ b/src-tauri/src/inject/event.js
@@ -715,16 +715,14 @@ document.addEventListener("DOMContentLoaded", () => {
     Boolean(anchorElement.download) || isDownloadableFile(url);
 
   const handleExternalLink = (url) => {
-    // Don't try to open blob: or data: URLs with shell
+    // Don't try to open blob: or data: URLs with the system URL handler.
     if (isSpecialDownload(url)) {
-      console.warn("Cannot open special URL with shell:", url);
+      console.warn("Cannot open special URL with opener:", url);
       return;
     }
 
-    invoke("plugin:shell|open", {
-      path: url,
-    }).catch((error) => {
-      console.error("Failed to open URL with shell:", url, error);
+    invoke("plugin:opener|open_url", { url }).catch((error) => {
+      console.error("Failed to open URL with opener:", url, error);
     });
   };
 
@@ -1219,7 +1217,7 @@ document.addEventListener("DOMContentLoaded", () => {
             navigator.clipboard.writeText(data.url),
           ),
           createMenuItem(menuTexts.openInBrowser, () =>
-            invoke("plugin:shell|open", { path: data.url }),
+            handleExternalLink(data.url),
           ),
         );
         break;
@@ -1243,7 +1241,7 @@ document.addEventListener("DOMContentLoaded", () => {
             navigator.clipboard.writeText(data.url),
           ),
           createMenuItem(menuTexts.openInBrowser, () =>
-            invoke("plugin:shell|open", { path: data.url }),
+            handleExternalLink(data.url),
           ),
         );
         break;

--- a/tests/unit/event-link-guard.test.js
+++ b/tests/unit/event-link-guard.test.js
@@ -146,6 +146,28 @@ function makeClickEvent(anchor) {
 }
 
 describe("event link guard", () => {
+  it("grants only the supported external protocol entry points", () => {
+    const capability = JSON.parse(
+      fs.readFileSync(
+        path.join(process.cwd(), "src-tauri/capabilities/default.json"),
+        "utf-8",
+      ),
+    );
+    const openerPermission = capability.permissions.find(
+      (permission) =>
+        typeof permission === "object" &&
+        permission.identifier === "opener:allow-open-url",
+    );
+
+    expect(openerPermission.allow).toEqual([
+      { url: "sms:*" },
+      { url: "geo:*" },
+      { url: "tencent://ntqq-open[?]*" },
+      { url: "mqqapi://userprofile/friend_profile_card[?]*" },
+      { url: "mqq://card/show_pslcard[?]*" },
+    ]);
+  });
+
   it("falls back from malformed saved zoom values", () => {
     const context = loadEventHelpers({
       withTauri: true,
@@ -538,10 +560,33 @@ describe("event link guard", () => {
     expect(event.preventDefault).toHaveBeenCalled();
     expect(event.stopImmediatePropagation).toHaveBeenCalled();
     expect(context.invokeCalls).toContainEqual([
-      "plugin:shell|open",
-      { path: "https://other.example.org/page" },
+      "plugin:opener|open_url",
+      { url: "https://other.example.org/page" },
     ]);
   });
+
+  it.each([
+    "sms:+15551234567?body=Hello",
+    "geo:31.2304,121.4737",
+    "tencent://ntqq-open?subcmd=OpenRobotProfile&robot_uin=962283577",
+  ])(
+    "opens supported external protocol links with the native handler",
+    (url) => {
+      const context = loadEventHelpers({ withTauri: true });
+      context.window.pakeConfig = { new_window: false };
+      runDomReady(context);
+
+      const event = makeClickEvent(makeAnchor(url, "_self"));
+      getClickGuard(context)(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(event.stopImmediatePropagation).toHaveBeenCalled();
+      expect(context.invokeCalls).toContainEqual([
+        "plugin:opener|open_url",
+        { url },
+      ]);
+    },
+  );
 
   it("bridges Web Badging API calls to explicit badge commands", async () => {
     const { navigator, invokeCalls } = loadEventHelpers({ withTauri: true });


### PR DESCRIPTION
## What

- Route external URLs through Tauri's scoped opener plugin.
- Preserve the existing HTTP(S), mailto, and tel behavior.
- Add the standardized `sms:` and `geo:` URI schemes.
- Allow only three fixed QQ profile entry points instead of wildcard custom schemes.
- Keep context-menu browser opening on the same guarded path.

## Security

- Does not allow arbitrary custom protocols.
- Does not enable `file:`, payment, installer, download, remote-control, or command schemes.
- `sms:` opens a composition flow and RFC 5724 requires user confirmation before sending.
- `geo:` only identifies a geographic location as defined by RFC 5870.

## Verification

- `pnpm exec vitest run tests/unit/event-link-guard.test.js` — 32 passed.
- `cargo check --locked` — passed.
- Full Vitest suite — 339 passed; two unrelated symlink tests require Windows Developer Mode or elevated symlink privileges.
