### PR TITLE
fix: defer image dependencies until icon processing

### DIFF
--- a/bin/options/icon.ts
+++ b/bin/options/icon.ts
@@ -3,6 +3,7 @@ import fsExtra from 'fs-extra';
 import chalk from 'chalk';
 import { dir } from 'tmp-promise';
 import { fileTypeFromBuffer } from 'file-type';
+import { execa } from 'execa';
 
 import logger from './logger';
 import { getSpinner } from '@/utils/info';
@@ -55,8 +56,21 @@ const ICON_CONFIG = {
 const PLATFORM_CONFIG: Record<'win' | 'linux' | 'macos', PlatformIconConfig> = {
   win: { format: '.ico', sizes: [...WIN_STANDARD_ICO_SIZES] },
   linux: { format: '.png', size: 512 },
-  macos: { format: '.icns', sizes: [16, 32, 64, 128, 256, 512, 1024] },
+  macos: { format: '.icns' },
 };
+
+const MACOS_ICONSET_FILES = [
+  ['icon_16x16.png', 16],
+  ['icon_16x16@2x.png', 32],
+  ['icon_32x32.png', 32],
+  ['icon_32x32@2x.png', 64],
+  ['icon_128x128.png', 128],
+  ['icon_128x128@2x.png', 256],
+  ['icon_256x256.png', 256],
+  ['icon_256x256@2x.png', 512],
+  ['icon_512x512.png', 512],
+  ['icon_512x512@2x.png', 1024],
+] as const;
 
 const API_KEYS = {
   logoDev: ['pk_JLLMUKGZRpaG5YclhXaTkg', 'pk_Ph745P8mQSeYFfW2Wk039A'],
@@ -209,6 +223,44 @@ async function applyMacOSMask(inputPath: string): Promise<string> {
   }
 }
 
+export async function generateMacOSIcns(
+  inputPath: string,
+  outputDir: string,
+  iconName: string,
+): Promise<string> {
+  const sharp = await loadSharp();
+  const iconsetPath = path.join(outputDir, `${iconName}.iconset`);
+  const outputPath = path.join(
+    outputDir,
+    `${iconName}${PLATFORM_CONFIG.macos.format}`,
+  );
+  await fsExtra.ensureDir(iconsetPath);
+
+  const source = sharp(inputPath);
+  await Promise.all(
+    MACOS_ICONSET_FILES.map(async ([fileName, size]) => {
+      await source
+        .clone()
+        .resize(size, size, {
+          fit: 'contain',
+          background: ICON_CONFIG.transparentBackground,
+        })
+        .ensureAlpha()
+        .png()
+        .toFile(path.join(iconsetPath, fileName));
+    }),
+  );
+
+  await execa('/usr/bin/iconutil', [
+    '-c',
+    'icns',
+    iconsetPath,
+    '-o',
+    outputPath,
+  ]);
+  return outputPath;
+}
+
 /**
  * Converts icon to platform-specific format
  */
@@ -274,14 +326,10 @@ async function convertIconFormat(
 
     // macOS
     const macIconPath = await applyMacOSMask(processedInputPath);
-    const { default: icongen } = await import('icon-gen');
-    await icongen(macIconPath, platformOutputDir, {
-      report: false,
-      icns: { name: iconName, sizes: PLATFORM_CONFIG.macos.sizes },
-    });
-    const outputPath = path.join(
+    const outputPath = await generateMacOSIcns(
+      macIconPath,
       platformOutputDir,
-      `${iconName}${PLATFORM_CONFIG.macos.format}`,
+      iconName,
     );
     return (await fsExtra.pathExists(outputPath)) ? outputPath : null;
   } catch (error) {

--- a/bin/options/icon.ts
+++ b/bin/options/icon.ts
@@ -3,8 +3,6 @@ import fsExtra from 'fs-extra';
 import chalk from 'chalk';
 import { dir } from 'tmp-promise';
 import { fileTypeFromBuffer } from 'file-type';
-import icongen from 'icon-gen';
-import sharp from 'sharp';
 
 import logger from './logger';
 import { getSpinner } from '@/utils/info';
@@ -29,6 +27,13 @@ type PlatformIconConfig = {
   sizes?: number[];
   size?: number;
 };
+
+type Sharp = (typeof import('sharp'))['default'];
+
+async function loadSharp(): Promise<Sharp> {
+  return (await import('sharp')).default;
+}
+
 const ICON_CONFIG = {
   minFileSize: 100,
   supportedFormats: [
@@ -134,6 +139,7 @@ async function preprocessIcon(inputPath: string): Promise<string> {
       return inputPath;
     }
 
+    const sharp = await loadSharp();
     const { path: tempDir } = await dir();
     const outputPath = path.join(tempDir, 'icon-normalized.png');
 
@@ -153,6 +159,7 @@ async function preprocessIcon(inputPath: string): Promise<string> {
  */
 async function applyMacOSMask(inputPath: string): Promise<string> {
   try {
+    const sharp = await loadSharp();
     const { path: tempDir } = await dir();
     const outputPath = path.join(tempDir, 'icon-macos-rounded.png');
 
@@ -221,6 +228,7 @@ async function convertIconFormat(
 
     // Generate platform-specific format
     if (IS_WIN) {
+      const sharp = await loadSharp();
       const icoPath = path.join(
         platformOutputDir,
         `${iconName}_256${PLATFORM_CONFIG.win.format}`,
@@ -245,6 +253,7 @@ async function convertIconFormat(
     }
 
     if (IS_LINUX) {
+      const sharp = await loadSharp();
       const outputPath = path.join(
         platformOutputDir,
         `${iconName}_${PLATFORM_CONFIG.linux.size}${PLATFORM_CONFIG.linux.format}`,
@@ -265,6 +274,7 @@ async function convertIconFormat(
 
     // macOS
     const macIconPath = await applyMacOSMask(processedInputPath);
+    const { default: icongen } = await import('icon-gen');
     await icongen(macIconPath, platformOutputDir, {
       report: false,
       icns: { name: iconName, sizes: PLATFORM_CONFIG.macos.sizes },
@@ -288,6 +298,7 @@ async function isLinuxBundleIconReady(iconPath: string): Promise<boolean> {
   }
 
   try {
+    const sharp = await loadSharp();
     const { width, height } = await sharp(iconPath).metadata();
     return (
       width === PLATFORM_CONFIG.linux.size &&

--- a/bin/utils/ico.ts
+++ b/bin/utils/ico.ts
@@ -1,6 +1,11 @@
 import path from 'path';
 import fsExtra from 'fs-extra';
-import sharp from 'sharp';
+
+type Sharp = (typeof import('sharp'))['default'];
+
+async function loadSharp(): Promise<Sharp> {
+  return (await import('sharp')).default;
+}
 
 const ICO_HEADER_SIZE = 6;
 const ICO_DIR_ENTRY_SIZE = 16;
@@ -186,6 +191,7 @@ async function pickLargestFrameAsPng(
   // Fallback: let sharp render directly from the ICO buffer. sharp picks the
   // largest embedded frame on its own.
   try {
+    const sharp = await loadSharp();
     return await sharp(buffer).png().toBuffer();
   } catch {
     return null;
@@ -218,6 +224,7 @@ export async function ensureMultiResolutionIco(
       );
     }
 
+    const sharp = await loadSharp();
     const frames = await Promise.all(
       desiredSizes.map(async (size) => {
         // Reuse an existing exact-size PNG frame when possible to keep any

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -14,8 +14,6 @@ import fs from 'fs';
 import fs$1 from 'fs/promises';
 import { dir } from 'tmp-promise';
 import { fileTypeFromBuffer } from 'file-type';
-import icongen from 'icon-gen';
-import sharp from 'sharp';
 import * as psl from 'psl';
 import { InvalidArgumentError, program as program$1, Option } from 'commander';
 
@@ -2114,6 +2112,9 @@ function getIconSourcePriority(url, appName) {
         : ['domain', 'dashboard'];
 }
 
+async function loadSharp$1() {
+    return (await import('sharp')).default;
+}
 const ICO_HEADER_SIZE = 6;
 const ICO_DIR_ENTRY_SIZE = 16;
 const ICO_TYPE_ICON = 1;
@@ -2247,6 +2248,7 @@ async function pickLargestFrameAsPng(buffer, entries) {
     // Fallback: let sharp render directly from the ICO buffer. sharp picks the
     // largest embedded frame on its own.
     try {
+        const sharp = await loadSharp$1();
         return await sharp(buffer).png().toBuffer();
     }
     catch {
@@ -2268,6 +2270,7 @@ async function ensureMultiResolutionIco(sourcePath, outputPath, preferredSize = 
         if (!sourcePng) {
             return await writeIcoWithPreferredSize(sourcePath, outputPath, preferredSize);
         }
+        const sharp = await loadSharp$1();
         const frames = await Promise.all(desiredSizes.map(async (size) => {
             // Reuse an existing exact-size PNG frame when possible to keep any
             // hand-tuned small icon (e.g. a 16x16 with deliberate pixel hinting).
@@ -2334,6 +2337,9 @@ function buildIcoFromPngBuffers(frames) {
     return output;
 }
 
+async function loadSharp() {
+    return (await import('sharp')).default;
+}
 const ICON_CONFIG = {
     minFileSize: 100,
     supportedFormats: [
@@ -2414,6 +2420,7 @@ async function preprocessIcon(inputPath) {
         if (!shouldNormalize) {
             return inputPath;
         }
+        const sharp = await loadSharp();
         const { path: tempDir } = await dir();
         const outputPath = path.join(tempDir, 'icon-normalized.png');
         await sharp(inputPath).ensureAlpha().png().toFile(outputPath);
@@ -2431,6 +2438,7 @@ async function preprocessIcon(inputPath) {
  */
 async function applyMacOSMask(inputPath) {
     try {
+        const sharp = await loadSharp();
         const { path: tempDir } = await dir();
         const outputPath = path.join(tempDir, 'icon-macos-rounded.png');
         // 1. Create a 1024x1024 rounded rect mask
@@ -2488,6 +2496,7 @@ async function convertIconFormat(inputPath, appName) {
         const iconName = getIconBaseName(appName);
         // Generate platform-specific format
         if (IS_WIN) {
+            const sharp = await loadSharp();
             const icoPath = path.join(platformOutputDir, `${iconName}_256${PLATFORM_CONFIG.win.format}`);
             const sourceBuffer = await fsExtra.readFile(processedInputPath);
             const frames = await Promise.all(PLATFORM_CONFIG.win.sizes.map(async (size) => {
@@ -2506,6 +2515,7 @@ async function convertIconFormat(inputPath, appName) {
             return icoPath;
         }
         if (IS_LINUX) {
+            const sharp = await loadSharp();
             const outputPath = path.join(platformOutputDir, `${iconName}_${PLATFORM_CONFIG.linux.size}${PLATFORM_CONFIG.linux.format}`);
             // Ensure we convert to proper PNG format with correct size
             await sharp(processedInputPath)
@@ -2520,6 +2530,7 @@ async function convertIconFormat(inputPath, appName) {
         }
         // macOS
         const macIconPath = await applyMacOSMask(processedInputPath);
+        const { default: icongen } = await import('icon-gen');
         await icongen(macIconPath, platformOutputDir, {
             report: false,
             icns: { name: iconName, sizes: PLATFORM_CONFIG.macos.sizes },
@@ -2539,6 +2550,7 @@ async function isLinuxBundleIconReady(iconPath) {
         return false;
     }
     try {
+        const sharp = await loadSharp();
         const { width, height } = await sharp(iconPath).metadata();
         return (width === PLATFORM_CONFIG.linux.size &&
             height === PLATFORM_CONFIG.linux.size);

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -21,7 +21,7 @@ var name = "pake-cli";
 var version = "3.15.6";
 var description = "🤱🏻 Turn any webpage into a desktop app with one command. 🤱🏻 一键打包网页生成轻量桌面应用。";
 var engines = {
-	node: ">=20.0.0"
+	node: ">=20.9.0"
 };
 var packageManager = "pnpm@10.26.2";
 var bin = {
@@ -78,7 +78,6 @@ var dependencies = {
 	execa: "^9.6.1",
 	"file-type": "^21.3.4",
 	"fs-extra": "^11.3.3",
-	"icon-gen": "^5.0.0",
 	loglevel: "^1.9.2",
 	ora: "^9.3.0",
 	prompts: "^2.4.2",
@@ -2360,8 +2359,20 @@ const ICON_CONFIG = {
 const PLATFORM_CONFIG = {
     win: { format: '.ico', sizes: [...WIN_STANDARD_ICO_SIZES] },
     linux: { format: '.png', size: 512 },
-    macos: { format: '.icns', sizes: [16, 32, 64, 128, 256, 512, 1024] },
+    macos: { format: '.icns' },
 };
+const MACOS_ICONSET_FILES = [
+    ['icon_16x16.png', 16],
+    ['icon_16x16@2x.png', 32],
+    ['icon_32x32.png', 32],
+    ['icon_32x32@2x.png', 64],
+    ['icon_128x128.png', 128],
+    ['icon_128x128@2x.png', 256],
+    ['icon_256x256.png', 256],
+    ['icon_256x256@2x.png', 512],
+    ['icon_512x512.png', 512],
+    ['icon_512x512@2x.png', 1024],
+];
 const API_KEYS = {
     logoDev: ['pk_JLLMUKGZRpaG5YclhXaTkg', 'pk_Ph745P8mQSeYFfW2Wk039A'],
     brandfetch: ['1idqvJC0CeFSeyp3Yf7', '1idej-yhU_ThggIHFyG'],
@@ -2482,6 +2493,32 @@ async function applyMacOSMask(inputPath) {
         return inputPath;
     }
 }
+async function generateMacOSIcns(inputPath, outputDir, iconName) {
+    const sharp = await loadSharp();
+    const iconsetPath = path.join(outputDir, `${iconName}.iconset`);
+    const outputPath = path.join(outputDir, `${iconName}${PLATFORM_CONFIG.macos.format}`);
+    await fsExtra.ensureDir(iconsetPath);
+    const source = sharp(inputPath);
+    await Promise.all(MACOS_ICONSET_FILES.map(async ([fileName, size]) => {
+        await source
+            .clone()
+            .resize(size, size, {
+            fit: 'contain',
+            background: ICON_CONFIG.transparentBackground,
+        })
+            .ensureAlpha()
+            .png()
+            .toFile(path.join(iconsetPath, fileName));
+    }));
+    await execa('/usr/bin/iconutil', [
+        '-c',
+        'icns',
+        iconsetPath,
+        '-o',
+        outputPath,
+    ]);
+    return outputPath;
+}
 /**
  * Converts icon to platform-specific format
  */
@@ -2530,12 +2567,7 @@ async function convertIconFormat(inputPath, appName) {
         }
         // macOS
         const macIconPath = await applyMacOSMask(processedInputPath);
-        const { default: icongen } = await import('icon-gen');
-        await icongen(macIconPath, platformOutputDir, {
-            report: false,
-            icns: { name: iconName, sizes: PLATFORM_CONFIG.macos.sizes },
-        });
-        const outputPath = path.join(platformOutputDir, `${iconName}${PLATFORM_CONFIG.macos.format}`);
+        const outputPath = await generateMacOSIcns(macIconPath, platformOutputDir, iconName);
         return (await fsExtra.pathExists(outputPath)) ? outputPath : null;
     }
     catch (error) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.15.6",
   "description": "🤱🏻 Turn any webpage into a desktop app with one command. 🤱🏻 一键打包网页生成轻量桌面应用。",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "packageManager": "pnpm@10.26.2",
   "bin": {
@@ -60,7 +60,6 @@
     "execa": "^9.6.1",
     "file-type": "^21.3.4",
     "fs-extra": "^11.3.3",
-    "icon-gen": "^5.0.0",
     "loglevel": "^1.9.2",
     "ora": "^9.3.0",
     "prompts": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,9 +34,6 @@ importers:
       fs-extra:
         specifier: ^11.3.3
         version: 11.3.3
-      icon-gen:
-        specifier: ^5.0.0
-        version: 5.0.0(@types/node@25.3.2)
       loglevel:
         specifier: ^1.9.2
         version: 1.9.2
@@ -858,10 +855,6 @@ packages:
     resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
     engines: {node: '>=18.20'}
 
-  commander@12.1.0:
-    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
-    engines: {node: '>=18'}
-
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
@@ -1006,11 +999,6 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
-
-  icon-gen@5.0.0:
-    resolution: {integrity: sha512-9C1FWnx7gP+HmvcaQziDtmqv2sHChB1wE1yuI59aCThvOpOAse4REsZr6vRwZ7UMBSKHfR9GHQqUBzCRBurfpQ==}
-    engines: {node: '>= 20'}
-    hasBin: true
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1178,10 +1166,6 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
-
-  pngjs@7.0.0:
-    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
-    engines: {node: '>=14.19.0'}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -2086,8 +2070,6 @@ snapshots:
 
   cli-spinners@3.4.0: {}
 
-  commander@12.1.0: {}
-
   commander@14.0.3: {}
 
   commander@2.20.3: {}
@@ -2253,14 +2235,6 @@ snapshots:
 
   human-signals@8.0.1: {}
 
-  icon-gen@5.0.0(@types/node@25.3.2):
-    dependencies:
-      commander: 12.1.0
-      pngjs: 7.0.0
-      sharp: 0.35.3(@types/node@25.3.2)
-    transitivePeerDependencies:
-      - '@types/node'
-
   ieee754@1.2.1: {}
 
   ini@1.3.8: {}
@@ -2393,8 +2367,6 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
-
-  pngjs@7.0.0: {}
 
   postcss@8.5.6:
     dependencies:

--- a/tests/index.js
+++ b/tests/index.js
@@ -7,11 +7,20 @@
  * test files with a single, easy-to-use interface.
  */
 
-import { execSync, spawn } from "child_process";
+import { execSync, spawn, spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import ora from "ora";
 import config, { TIMEOUTS, TEST_URLS } from "./config.js";
+
+const rejectImageDependenciesLoader = `data:text/javascript,${encodeURIComponent(`
+  export async function resolve(specifier, context, nextResolve) {
+    if (specifier === "sharp" || specifier === "icon-gen") {
+      throw new Error("Image dependency loaded during CLI startup: " + specifier);
+    }
+    return nextResolve(specifier, context);
+  }
+`)}`;
 
 class PakeTestRunner {
   constructor() {
@@ -196,6 +205,31 @@ class PakeTestRunner {
           timeout: TIMEOUTS.QUICK,
         });
         return /^\d+\.\d+\.\d+/.test(output.trim());
+      },
+      TIMEOUTS.QUICK,
+    );
+
+    // Metadata-only commands must not initialize native image tooling.
+    await this.runTest(
+      "Version Command Without Image Dependencies",
+      () => {
+        const result = spawnSync(
+          process.execPath,
+          [
+            "--no-warnings",
+            "--experimental-loader",
+            rejectImageDependenciesLoader,
+            config.CLI_PATH,
+            "--version",
+          ],
+          {
+            encoding: "utf8",
+            timeout: TIMEOUTS.QUICK,
+          },
+        );
+        return (
+          result.status === 0 && /^\d+\.\d+\.\d+/.test(result.stdout.trim())
+        );
       },
       TIMEOUTS.QUICK,
     );

--- a/tests/index.js
+++ b/tests/index.js
@@ -15,7 +15,7 @@ import config, { TIMEOUTS, TEST_URLS } from "./config.js";
 
 const rejectImageDependenciesLoader = `data:text/javascript,${encodeURIComponent(`
   export async function resolve(specifier, context, nextResolve) {
-    if (specifier === "sharp" || specifier === "icon-gen") {
+    if (specifier === "sharp") {
       throw new Error("Image dependency loaded during CLI startup: " + specifier);
     }
     return nextResolve(specifier, context);
@@ -349,8 +349,10 @@ class PakeTestRunner {
         );
 
         const essentialDeps = ["commander", "chalk", "fs-extra", "execa"];
-        return essentialDeps.every(
-          (dep) => packageJson.dependencies && packageJson.dependencies[dep],
+        return (
+          essentialDeps.every(
+            (dep) => packageJson.dependencies && packageJson.dependencies[dep],
+          ) && !packageJson.dependencies["icon-gen"]
         );
       } catch {
         return false;

--- a/tests/unit/icon.test.ts
+++ b/tests/unit/icon.test.ts
@@ -1,11 +1,20 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import sharp from 'sharp';
 
-import { downloadIcon } from '@/options/icon';
+const execaMock = vi.hoisted(() => vi.fn());
+
+vi.mock('execa', () => ({
+  execa: execaMock,
+}));
+
+import { downloadIcon, generateMacOSIcns } from '@/options/icon';
 import { getIconSourcePriority } from '@/utils/icon-source';
 
 const downloadedIconPaths: string[] = [];
+const generatedIconDirs: string[] = [];
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -22,6 +31,66 @@ afterEach(() => {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   }
+
+  while (generatedIconDirs.length > 0) {
+    const tempDir = generatedIconDirs.pop();
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('generateMacOSIcns', () => {
+  it('builds a complete iconset before calling the system converter', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pake-icns-'));
+    generatedIconDirs.push(tempDir);
+    const sourcePath = path.join(tempDir, 'source.svg');
+    fs.writeFileSync(
+      sourcePath,
+      '<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024"><rect width="1024" height="1024" fill="#123456"/></svg>',
+    );
+
+    const expectedSizes = new Map([
+      ['icon_16x16.png', 16],
+      ['icon_16x16@2x.png', 32],
+      ['icon_32x32.png', 32],
+      ['icon_32x32@2x.png', 64],
+      ['icon_128x128.png', 128],
+      ['icon_128x128@2x.png', 256],
+      ['icon_256x256.png', 256],
+      ['icon_256x256@2x.png', 512],
+      ['icon_512x512.png', 512],
+      ['icon_512x512@2x.png', 1024],
+    ]);
+
+    execaMock.mockImplementation(async (command: string, args: string[]) => {
+      expect(command).toBe('/usr/bin/iconutil');
+      expect(args.slice(0, 2)).toEqual(['-c', 'icns']);
+
+      const iconsetPath = args[2];
+      const outputPath = args[4];
+      expect(fs.readdirSync(iconsetPath).sort()).toEqual(
+        [...expectedSizes.keys()].sort(),
+      );
+
+      for (const [fileName, size] of expectedSizes) {
+        const metadata = await sharp(
+          path.join(iconsetPath, fileName),
+        ).metadata();
+        expect(metadata.width).toBe(size);
+        expect(metadata.height).toBe(size);
+      }
+
+      fs.writeFileSync(outputPath, 'test-icns');
+      return { exitCode: 0 };
+    });
+
+    const outputPath = await generateMacOSIcns(sourcePath, tempDir, 'example');
+
+    expect(outputPath).toBe(path.join(tempDir, 'example.icns'));
+    expect(fs.readFileSync(outputPath, 'utf8')).toBe('test-icns');
+    expect(execaMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('icon source priority', () => {


### PR DESCRIPTION
## Summary

- load `sharp` only when icon processing begins
- load `icon-gen` only for macOS icon conversion
- keep `pake --version` independent of native image startup

Related: #1350

## Why

The shipped CLI currently imports both image dependencies before Commander handles metadata flags. A native Sharp load failure therefore prevents `--version`, even though that command does not process an icon.

## Tests

- loader-blocked regression for `sharp` and `icon-gen`: `pake --version` exits 0 and prints `3.15.6`
- `pnpm exec vitest run tests/unit/ico.test.ts tests/unit/icon.test.ts tests/unit/linux-icon.test.ts` (18 passed)
- `pnpm run cli:build`
- `npm pack --dry-run --ignore-scripts`
