### PR TITLE
feat: Save window state on exit and add Windows x64 build workflow

### DIFF
--- a/.github/workflows/build-common-windows-apps.yaml
+++ b/.github/workflows/build-common-windows-apps.yaml
@@ -1,0 +1,202 @@
+name: Build Common Windows Apps
+
+env:
+  NODE_VERSION: "22.11.0"
+  PNPM_VERSION: "9.14.4"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Apps (Windows x64)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable-x86_64-msvc
+
+      - name: Setup Node.js Environment
+        uses: ./.github/actions/setup-env
+        with:
+          mode: node
+
+      - name: Get Pake version
+        id: pake_version
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Pake version: $VERSION"
+
+      - name: Get release counter for app version
+        id: build_counter
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pakeVersion = '${{ steps.pake_version.outputs.version }}';
+            const releasePrefix = `apps-${pakeVersion}-`;
+
+            try {
+              // Get all releases
+              const { data: releases } = await github.rest.repos.listReleases({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100
+              });
+
+              // Count releases for this version prefix
+              const matchingReleases = releases.filter(r => r.tag_name && r.tag_name.startsWith(releasePrefix));
+              const counter = matchingReleases.length + 1;
+              console.log(`Release counter for ${pakeVersion}: ${counter}`);
+              return counter;
+            } catch (error) {
+              console.log('Error managing counter, using 1:', error.message);
+              return 1;
+            }
+
+      - name: Rust cache restore
+        uses: actions/cache/restore@v4.2.0
+        id: rust_cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            src-tauri/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build pake-cli
+        shell: bash
+        run: |
+          echo "Building pake-cli..."
+          pnpm run cli:build
+
+          # Verify build output
+          if [ ! -f "dist/cli.js" ]; then
+            echo "Error: Failed to build pake-cli"
+            exit 1
+          fi
+
+          echo "pake-cli built successfully"
+
+      - name: Build all apps with pake-cli
+        timeout-minutes: 60
+        shell: pwsh
+        run: |
+          Write-Host "Building all apps from apps.json"
+          $baseVersion = "${{ steps.pake_version.outputs.version }}"
+          $buildCounter = "${{ steps.build_counter.outputs.result }}"
+          # Convert X.X.X to X.XX format (e.g., 3.5.2 -> 3.52)
+          $parts = $baseVersion.Split('.')
+          $majorMinor = "$($parts[0]).$($parts[1])$($parts[2])"
+          $semverVersion = "${majorMinor}.${buildCounter}"
+          Write-Host "Version: $semverVersion"
+
+          # Read apps.json
+          $appsData = Get-Content -Path 'apps.json' -Raw | ConvertFrom-Json
+          $apps = $appsData.apps
+          if (-not $apps) {
+            Write-Error 'No apps found in apps.json'
+            exit 1
+          }
+
+          New-Item -Path 'output' -ItemType Directory -Force | Out-Null
+
+          foreach ($app in $apps) {
+            $name = $app.name
+            $url = $app.url
+            $icon = $app.icon
+            $width = if ($app.width) { $app.width } else { 1200 }
+            $height = if ($app.height) { $app.height } else { 780 }
+            $fullscreen = if ($app.fullscreen) { $app.fullscreen } else { $false }
+            $openLastUrl = if ($app.open_last_url) { $app.open_last_url } else { $false }
+            $alwaysOnTop = if ($app.always_on_top) { $app.always_on_top } else { $false }
+            $userAgent = $app.user_agent
+            $disabled = if ($app.disabled) { $app.disabled } else { $false }
+            $jsScriptUrl = $app.js_script_url
+
+            if ($disabled -eq $true) {
+              Write-Host "Skipping $name (disabled)"
+              continue
+            }
+
+            Write-Host "Building $name..."
+            $args = @('dist/cli.js', $url, '--name', $name, '--width', $width, '--height', $height, '--app-version', $semverVersion, '--enable-drag-drop', '--keep-binary')
+            if ($fullscreen -eq $true) { $args += '--fullscreen' }
+            if ($openLastUrl -eq $true) { $args += '--open-last-url' }
+            if ($alwaysOnTop -eq $true) { $args += '--always-on-top' }
+            if ($userAgent) { $args += @('--user-agent', $userAgent) }
+            if ($icon) { $args += @('--icon', $icon) }
+            if ($jsScriptUrl) {
+              $injectDir = Join-Path $PWD 'temp-inject'
+              New-Item -Path $injectDir -ItemType Directory -Force | Out-Null
+              # Use a static safe filename to avoid name-derived surprises
+              $injectPath = Join-Path $injectDir 'script.user.js'
+              Write-Host "Downloading js_script_url for $name from $jsScriptUrl"
+              Invoke-WebRequest -Uri $jsScriptUrl -OutFile $injectPath -UseBasicParsing
+              $args += @('--inject', $injectPath)
+            }
+
+            Write-Host 'Running: node ' + ($args -join ' ')
+            & node @args
+
+            # find newest exe
+            $exe = Get-ChildItem -Path '.' -Filter '*.exe' -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+            if (-not $exe) { Write-Error "No .exe produced for $name"; exit 1 }
+            $destName = "$name.exe"
+            Copy-Item -Path $exe.FullName -Destination "output\\$destName" -Force
+            Write-Host "Copied $($exe.Name) -> output\\$destName"
+            Remove-Item -Path $exe.FullName -Force
+            $msi = Get-ChildItem -Path '.' -Filter '*.msi' -ErrorAction SilentlyContinue
+            if ($msi) { Remove-Item -Path $msi.FullName -Force }
+          }
+
+      - name: List output artifacts
+        shell: pwsh
+        run: |
+          Write-Host "Output files:"
+          if (Test-Path output) {
+            Get-ChildItem -Path output -File | ForEach-Object { Write-Host $_.FullName }
+          } else {
+            Write-Error "No output directory found"
+            exit 1
+          }
+
+      - name: Rust cache store
+        uses: actions/cache/save@v4.2.0
+        if: steps.rust_cache.outputs.cache-hit != 'true'
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            src-tauri/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: apps-${{ steps.pake_version.outputs.version }}-${{ steps.build_counter.outputs.result }}
+          name: Apps ${{ steps.pake_version.outputs.version }}-${{ steps.build_counter.outputs.result }}
+          body: |
+            **Apps Release**
+            **Pake Version:** ${{ steps.pake_version.outputs.version }}
+            **Build:** ${{ steps.build_counter.outputs.result }}
+            **Platform:** Windows x64
+
+            This release contains the packaged applications defined in `apps.yml`.
+
+            Built with Pake ${{ steps.pake_version.outputs.version }}
+          files: output/*.exe
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-single-windows-app.yaml
+++ b/.github/workflows/build-single-windows-app.yaml
@@ -1,0 +1,257 @@
+name: Build Single Windows App
+
+env:
+  NODE_VERSION: "22.11.0"
+  PNPM_VERSION: "9.14.4"
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: "Application Name"
+        required: true
+      url:
+        description: "Application URL"
+        required: true
+      icon:
+        description: "Icon URL (Optional)"
+        required: false
+      always_on_top:
+        description: "Set window always on top"
+        required: false
+        type: boolean
+        default: false
+      open_last_url:
+        description: "Open last URL at startup"
+        required: false
+        type: boolean
+        default: false
+      fullscreen:
+        description: "Fullscreen at startup"
+        required: false
+        type: boolean
+        default: false
+      width:
+        description: "Window Width"
+        required: false
+        default: "1200"
+      height:
+        description: "Window Height"
+        required: false
+        default: "780"
+      user_agent:
+        description: "User Agent (Optional)"
+        required: false
+      inject_js_base64:
+        description: "Inject (base64) JS content (optional)"
+        required: false
+      inject_css_base64:
+        description: "Inject (base64) CSS content (optional)"
+        required: false
+      inject_js_url:
+        description: "Inject JS file from URL (optional)"
+        required: false
+      inject_css_url:
+        description: "Inject CSS file from URL (optional)"
+        required: false
+      debug:
+        description: "Enable debug mode"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    name: Build ${{ inputs.name }} (Windows x64)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable-x86_64-msvc
+
+      - name: Setup Node.js Environment
+        uses: ./.github/actions/setup-env
+        with:
+          mode: node
+
+      - name: Get Pake version
+        id: pake_version
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Pake version: $VERSION"
+
+      - name: Rust cache restore
+        uses: actions/cache/restore@v4.2.0
+        id: rust_cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            src-tauri/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build pake-cli
+        shell: bash
+        run: |
+          echo "Building pake-cli..."
+          pnpm run cli:build
+
+          # Verify build output
+          if [ ! -f "dist/cli.js" ]; then
+            echo "Error: Failed to build pake-cli"
+            exit 1
+          fi
+
+          echo "pake-cli built successfully"
+
+      - name: Prepare inject files
+        if: inputs.inject_js_base64 != '' || inputs.inject_css_base64 != '' || inputs.inject_js_url != '' || inputs.inject_css_url != ''
+        shell: pwsh
+        run: |
+          Write-Host "Preparing inject files..."
+          $injectDir = "inject_files"
+          New-Item -Path $injectDir -ItemType Directory -Force | Out-Null
+
+          # Handle JS file from base64
+          if ("${{ inputs.inject_js_base64 }}" -ne "") {
+            Write-Host "Decoding base64 JS content..."
+            $jsBase64 = "${{ inputs.inject_js_base64 }}"
+            $jsBytes = [System.Convert]::FromBase64String($jsBase64)
+            [System.IO.File]::WriteAllBytes("$injectDir\inject.js", $jsBytes)
+            Write-Host "Created inject.js from base64 ($($jsBytes.Length) bytes)"
+          }
+          # Handle JS file from URL
+          elseif ("${{ inputs.inject_js_url }}" -ne "") {
+            Write-Host "Downloading JS file from URL..."
+            $jsUrl = "${{ inputs.inject_js_url }}"
+            Invoke-WebRequest -Uri $jsUrl -OutFile "$injectDir\inject.js"
+            Write-Host "Downloaded inject.js from $jsUrl"
+          }
+
+          # Handle CSS file from base64
+          if ("${{ inputs.inject_css_base64 }}" -ne "") {
+            Write-Host "Decoding base64 CSS content..."
+            $cssBase64 = "${{ inputs.inject_css_base64 }}"
+            $cssBytes = [System.Convert]::FromBase64String($cssBase64)
+            [System.IO.File]::WriteAllBytes("$injectDir\inject.css", $cssBytes)
+            Write-Host "Created inject.css from base64 ($($cssBytes.Length) bytes)"
+          }
+          # Handle CSS file from URL
+          elseif ("${{ inputs.inject_css_url }}" -ne "") {
+            Write-Host "Downloading CSS file from URL..."
+            $cssUrl = "${{ inputs.inject_css_url }}"
+            Invoke-WebRequest -Uri $cssUrl -OutFile "$injectDir\inject.css"
+            Write-Host "Downloaded inject.css from $cssUrl"
+          }
+
+          Write-Host "Inject files prepared in $injectDir"
+
+      - name: Build app with pake-cli
+        timeout-minutes: 20
+        shell: pwsh
+        run: |
+          Write-Host "Building ${{ inputs.name }}..."
+          $semverVersion = "${{ steps.pake_version.outputs.version }}"
+          Write-Host "Version: $semverVersion"
+
+          New-Item -Path 'output' -ItemType Directory -Force | Out-Null
+
+          $name = "${{ inputs.name }}"
+          $url = "${{ inputs.url }}"
+          $width = "${{ inputs.width }}"
+          $height = "${{ inputs.height }}"
+
+          $args = @('dist/cli.js', $url, '--name', $name, '--width', $width, '--height', $height, '--app-version', $semverVersion, '--enable-drag-drop', '--keep-binary')
+
+          if ("${{ inputs.fullscreen }}" -eq "true") {
+            $args += '--fullscreen'
+          }
+
+          if ("${{ inputs.always_on_top }}" -eq "true") {
+            $args += '--always-on-top'
+          }
+
+          if ("${{ inputs.open_last_url }}" -eq "true") {
+            $args += '--open-last-url'
+          }
+
+          if ("${{ inputs.user_agent }}" -ne "") {
+            $args += @('--user-agent', "${{ inputs.user_agent }}")
+          }
+
+          if ("${{ inputs.icon }}" -ne "") {
+            $args += @('--icon', "${{ inputs.icon }}")
+          }
+
+          if ("${{ inputs.debug }}" -eq "true") {
+            $args += '--debug'
+          }
+
+          if ("${{ inputs.inject_js_base64 }}" -ne "" -or "${{ inputs.inject_css_base64 }}" -ne "" -or "${{ inputs.inject_js_url }}" -ne "" -or "${{ inputs.inject_css_url }}" -ne "") {
+            $injectDir = "inject_files"
+            if (Test-Path "$injectDir\inject.js") {
+              $args += @('--inject', "$injectDir\inject.js")
+            }
+            if (Test-Path "$injectDir\inject.css") {
+              $args += @('--inject', "$injectDir\inject.css")
+            }
+          }
+
+          Write-Host 'Running: node ' + ($args -join ' ')
+          & node @args
+
+          # find newest exe
+          $exe = Get-ChildItem -Path '.' -Filter '*.exe' -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $exe) {
+            Write-Error "No .exe produced for $name"
+            exit 1
+          }
+
+          $destName = "$name.exe"
+          Copy-Item -Path $exe.FullName -Destination "output\\$destName" -Force
+          Write-Host "Copied $($exe.Name) -> output\\$destName"
+          Remove-Item -Path $exe.FullName -Force
+
+          $msi = Get-ChildItem -Path '.' -Filter '*.msi' -ErrorAction SilentlyContinue
+          if ($msi) {
+            Remove-Item -Path $msi.FullName -Force
+          }
+
+      - name: List output artifacts
+        shell: pwsh
+        run: |
+          Write-Host "Output files:"
+          if (Test-Path output) {
+            Get-ChildItem -Path output -File | ForEach-Object { Write-Host $_.FullName }
+          } else {
+            Write-Error "No output directory found"
+            exit 1
+          }
+
+      - name: Rust cache store
+        uses: actions/cache/save@v4.2.0
+        if: steps.rust_cache.outputs.cache-hit != 'true'
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            src-tauri/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.name }}-windows-x64
+          path: output/*.exe
+          retention-days: 30

--- a/apps.json
+++ b/apps.json
@@ -1,0 +1,34 @@
+{
+  "apps": [
+    {
+      "name": "Google Translate",
+      "url": "https://translate.google.com/?sl=no&tl=vi",
+      "icon": "https://www.gstatic.com/translate/favicon.ico"
+    },
+    {
+      "name": "Gmail",
+      "url": "https://mail.google.com/mail/",
+      "icon": "https://ssl.gstatic.com/ui/v1/icons/mail/rfr/gmail.ico"
+    },
+    {
+      "name": "Outlook",
+      "url": "https://outlook.office.com/mail/",
+      "icon": "https://res.public.onecdn.static.microsoft/owamail/20250918044.09/resources/images/favicons/mail-seen.ico"
+    },
+    {
+      "name": "Perplexity",
+      "url": "https://www.perplexity.ai/"
+    },
+    {
+      "name": "OneNote",
+      "url": "https://onenote.cloud.microsoft/",
+      "icon": "https://res.cdn.office.net/files/fabric-cdn-prod_20251010.003/assets/brand-icons/product/favicon/onenote.ico"
+    },
+    {
+      "name": "Youtube",
+      "url": "https://www.youtube.com/",
+      "icon": "https://www.youtube.com/s/desktop/d2ab3412/img/favicon.ico",
+      "js_script_url": "https://update.greasyfork.org/scripts/459541/YouTube%E5%8E%BB%E5%B9%BF%E5%91%8A.user.js"
+    }
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use std::sync::{
     Arc,
 };
 use tauri::{webview::PageLoadEvent, Manager, Url, WebviewWindow};
+use tauri_plugin_window_state::AppHandleExt;
 use tauri_plugin_window_state::Builder as WindowStatePlugin;
 use tauri_plugin_window_state::StateFlags;
 
@@ -384,6 +385,14 @@ pub fn run_app() {
                         let _ = window.hide();
                     });
                     api.prevent_close();
+                } else {
+                    // Save window state before exiting to preserve window position
+                    _window
+                        .app_handle()
+                        .save_window_state(StateFlags::all())
+                        .ok();
+                    // Exit app completely when hide_on_close is false
+                    std::process::exit(0);
                 }
                 // If hide_on_close is false, allow normal close behavior
                 // This lets tauri-plugin-window-state save the window position and size


### PR DESCRIPTION
## Changes

### 1. Save window state before exit
- Preserve window position and size when closing app with `hide_on_close` disabled
- Uses `tauri-plugin-window-state` `save_window_state()` before `process::exit`

### 2. GitHub Actions workflow for Windows x64 apps
- Add workflow and build script to automate Windows x64 app builds

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)